### PR TITLE
fix: Remove all default "Other options"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "TNG Technology Consulting GmbH",
   "name": "LLM Composer (dev)",
   "description": "A Thunderbird extension enabling LLM support while writing E-Mails",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-thunderbird",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A Thunderbird extension enabling LLM support while writing E-Mails",
   "main": "background.js",
   "scripts": {

--- a/public/options.html
+++ b/public/options.html
@@ -147,7 +147,12 @@
           <div class="form-group">
             <label for="context_window">Context window:</label>
             <input type="number" id="context_window" name="context window" min="1"/>
-            <label for="other_options">Other options:</label>
+            <label for="other_options">
+              Other options (json):
+              <sup title="These are options added as 'params' in the request body when calling the LLM endpoint configured above. See the documentation of that endpoint for available options. 'params.messages' is added/overwritten by the plugin. Typically a 'model' key can be used to select different models if available.">
+                &#8505;&#65039;
+              </sup>
+            </label>
             <textarea id="other_options" name="other option window"> </textarea>
           </div>
         </div>

--- a/src/optionsParams.ts
+++ b/src/optionsParams.ts
@@ -25,17 +25,7 @@ export interface Options {
   llmContext: string;
 }
 
-export const DEFAULT_PARAMS: LlmParameters = {
-  best_of: 1,
-  decoder_input_details: true,
-  max_new_tokens: 2000,
-  repetition_penalty: 1.03,
-  return_full_text: false,
-  temperature: 0.2,
-  typical_p: 0.95,
-  use_cache: true,
-  watermark: true,
-};
+export const DEFAULT_PARAMS: LlmParameters = {};
 
 export const DEFAULT_OPTIONS: Options = {
   model: "",


### PR DESCRIPTION
Great source of pain. We added those at some point in time but more than once they resulted in problems because the API spec was changed or the behaviour is not really the "default" one.