### PR TITLE
'Add email organization with LLM-based folder classification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md - tb-llm-composer
+
+Quick guide for coding agents in this repo.
+
+## What this project is
+
+**LLM Composer** is a **Thunderbird MV3 WebExtension** in **TypeScript** that adds LLM help while writing emails.
+
+Features:
+- **Compose** from a short prompt (`Ctrl+Alt+L`)
+- **Summarize** the reply thread (`Ctrl+Alt+K`)
+- **Cancel** an in-flight LLM request (`Ctrl+Alt+C`)
+- **Sort a folder** by classifying each message into configured folders (mail-tab action button)
+
+It uses any **OpenAI-compatible chat-completions HTTP endpoint**. Endpoint URL, optional bearer token, and model are configured on the options page.
+
+## Tech stack
+
+| Concern | Choice |
+| --- | --- |
+| Language | TypeScript 5 (strict), ES2022, ESM |
+| Package manager | **pnpm** (v10+), Node **>=22** (CI uses Node 24) |
+| Bundler | Webpack 5 (`ts-loader`, Terser) |
+| Linter/format | **Biome** (`biome.json`): 2 spaces, double quotes, width 120 |
+| Tests | **Vitest** (node env, `vitest-fetch-mock`) |
+| Types | `@types/thunderbird-webext-browser` (`browser.*`) |
+
+## Post-edit checklist (run in order)
+
+Run after every code change. CI (`.github/workflows/ci.yaml`) runs build, lint, test, and `pnpm audit`.
+
+```pwsh
+pnpm run lint
+pnpm run test
+pnpm run build
+```
+
+- Lint auto-fix: `pnpm run lint-fix` (safe) or `pnpm run lint-fix-unsafe` (unsafe)
+- Optional coverage: `pnpm run test-coverage`
+- Release package only: `pnpm run ship` -> `llm-thunderbird.xpi`
+
+## Project layout
+
+```text
+src/
+  background.ts              Entry point; registers all browser.* listeners for commands/menus/tabs/alarms and folder-sort action.
+  options.ts                 Options page logic (DOM in public/options.html).
+  optionsParams.ts           Option/parameter types, DEFAULT_OPTIONS, getPluginOptions() (reads browser.storage.sync).
+
+  llmButtonClickHandling.ts  compose()/summarize()/cancel() flows; per-tab request state (AllRequestsStatus); think-tag stripping;
+                             writes results via browser.compose.setComposeDetails.
+  llmConnection.ts           sendContentToLlm()/callLlmApi(); fetch to LLM endpoint; request/response types; abort + timeout.
+  promptAndContext.ts        Builds system/user messages (context + prompt) for body, subject, and summary generation.
+  emailOrganising.ts         organiseCurrentFolder(); organise folder messages via LLM and move with browser.messages.move() to FolderRule targets.
+
+  menu.ts                    compose_action menu entries + shortcut labels.
+  retrieveSentContext.ts     Gets recent sent mail to a recipient (writing style context).
+  originalTabConversation.ts Caches reply quote per tab in browser.storage.local.
+  emailHelpers.ts            MIME text extraction; first-recipient address helper.
+  keepAlive.ts               Alarm-based keep-alive to prevent MV3 suspension during long LLM calls (~90s idle threshold).
+  notifications.ts           timedNotification() + notifyOnError() wrapper.
+  utils.ts                   stripHtml(), getInputElement() helper.
+  thunderbird-alarms.d.ts    Ambient types for alarms API.
+  __tests__/                 Vitest specs + setupVitest.ts + testUtils.ts.
+
+manifest.json                MV3 source manifest. Webpack rewrites paths and strips " (dev)" / dev id for production.
+webpack.config.js            Builds background.ts + options.ts into build/; copies icons/, public/, and transformed manifest.json.
+public/options.html          Options page markup.
+icons/                       Extension icons + busy indicator (loader-32px.gif).
+docs/CONTRIBUTING.md         Dev/test/release instructions + sample test emails.
+docs/create_new_release.md   Release process.
+build/                       Generated webpack output (do not edit manually).
+```
+
+## Key flows
+
+- **Listener ordering is critical:** in `background.ts`, `browser.commands.onCommand` must remain the first statement or shortcuts can fail after event-page restart.
+- **Compose flow:** `executeLlmAction` -> `compose()` gathers compose details, recent sent mails, and reply quote; builds prompt/context in `promptAndContext.ts`; optionally generates subject; calls `sendContentToLlm`; writes result back and re-appends signature/quote.
+- **Per-tab request state:** singleton `allRequestsStatus` (`AllRequestsStatus`) holds an `AbortController` by `tabId`; cancel aborts active request; compose-action icon switches to `loader-32px.gif` while running.
+- **LLM HTTP call:** `callLlmApi` POSTs `{ messages, ...params }` to `options.model` (endpoint URL), adds `Authorization: Bearer` if token exists, merges user-abort and timeout signals, and wraps fetch with keep-alive.
+- **Folder sort flow:** mail-tab `browser.action` runs `sortCurrentFolder`; second click cancels through a separate `AbortController` map.
+- **Think-tag handling:** `<think>...</think>` is stripped unless `options.strip_think_tag` is `false`.
+
+## Conventions and gotchas
+
+- Use Promise-based `browser.*`, never `chrome.*`.
+- Persisted settings: `browser.storage.sync` under `options`; per-tab cache: `browser.storage.local`. Always read options via `getPluginOptions()` (merges with `DEFAULT_OPTIONS`).
+- TypeScript is strict: no unused locals/params, no implicit `any`, no fallthrough; prefer narrow typing and `LlmRoles` for message roles.
+- Log prefixes are namespaced (`SORT:`, `MENU:`, `LLM-CONNECTION:`, `KEEP-ALIVE:`, `LLM-CONVO-CACHE:`). Production build drops `console.log`/`console.info` via Terser `drop_console`; keep user-visible failures on `console.error` + notifications.
+- Preserve dev/prod split: new top-level buttons/titles should include `" (dev)"` in `manifest.json` so dev installs do not clash with production (`webpack.config.js` transform strips it for prod).
+- Tests run in node with `globals: true`; fetch/network is mocked by `vitest-fetch-mock` (`src/__tests__/setupVitest.ts`).
+- Plain-text compose is the only fully supported mode; HTML reply content is normalized with `stripHtml`, and storing HTML reply throws.
+
+## References
+
+- Thunderbird WebExtension API: https://webextension-api.thunderbird.net/en/stable/
+- Thunderbird add-on docs: https://developer.thunderbird.net/add-ons/about-add-ons
+- Local dev and temporary add-on loading: `docs/CONTRIBUTING.md`
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ build/                       Generated webpack output (do not edit manually).
 - Use Promise-based `browser.*`, never `chrome.*`.
 - Persisted settings: `browser.storage.sync` under `options`; per-tab cache: `browser.storage.local`. Always read options via `getPluginOptions()` (merges with `DEFAULT_OPTIONS`).
 - TypeScript is strict: no unused locals/params, no implicit `any`, no fallthrough; prefer narrow typing and `LlmRoles` for message roles.
+- Add really concise docstrings to functions whose behavior is not obvious from the prototype.
 - Log prefixes are namespaced (`SORT:`, `MENU:`, `LLM-CONNECTION:`, `KEEP-ALIVE:`, `LLM-CONVO-CACHE:`). Production build drops `console.log`/`console.info` via Terser `drop_console`; keep user-visible failures on `console.error` + notifications.
 - Preserve dev/prod split: new top-level buttons/titles should include `" (dev)"` in `manifest.json` so dev installs do not clash with production (`webpack.config.js` transform strips it for prod).
 - Tests run in node with `globals: true`; fetch/network is mocked by `vitest-fetch-mock` (`src/__tests__/setupVitest.ts`).
@@ -96,4 +97,3 @@ build/                       Generated webpack output (do not edit manually).
 - Thunderbird WebExtension API: https://webextension-api.thunderbird.net/en/stable/
 - Thunderbird add-on docs: https://developer.thunderbird.net/add-ons/about-add-ons
 - Local dev and temporary add-on loading: `docs/CONTRIBUTING.md`
-

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
     "browser_style": false
   },
   "action": {
-    "default_title": "Move E-Mails with LLM (dev)",
+    "default_title": "Organise Folder with LLM (dev)",
     "default_icon": {
       "16": "icons/icon-16px.png",
       "32": "icons/icon-32px.png",

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,17 @@
       "update_url": "https://raw.githubusercontent.com/TNG/tb-llm-composer/refs/heads/main/updates.json"
     }
   },
-  "permissions": ["menus", "compose", "storage", "notifications", "messagesRead", "accountsRead", "alarms"],
+  "permissions": [
+    "menus",
+    "compose",
+    "storage",
+    "notifications",
+    "messagesRead",
+    "accountsRead",
+    "alarms",
+    "messagesMove"
+  ],
+  "host_permissions": ["<all_urls>"],
   "icons": {
     "64": "icons/icon-64px.png",
     "32": "icons/icon-32px.png",
@@ -24,6 +34,14 @@
   "options_ui": {
     "page": "./build/public/options.html",
     "browser_style": false
+  },
+  "action": {
+    "default_title": "Move E-Mails with LLM (dev)",
+    "default_icon": {
+      "16": "icons/icon-16px.png",
+      "32": "icons/icon-32px.png",
+      "64": "icons/icon-64px.png"
+    }
   },
   "compose_action": {
     "default_title": "To LLM (dev)",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "zip:darwin:linux": "cd build && zip -r ../llm-thunderbird.xpi ./*",
     "zip:win32": "cd build && 7z a -tzip ../llm-thunderbird.xpi ./*",
     "ship": "pnpm run build && pnpm run zip",
-    "test": "vitest",
-    "test-coverage": "vitest --coverage",
+    "test": "vitest run",
+    "test-coverage": "vitest run --coverage",
     "lint": "biome ci ./",
     "lint-fix": "biome check --write ./",
     "lint-fix-unsafe": "biome check --unsafe --write ./"

--- a/public/options.html
+++ b/public/options.html
@@ -68,6 +68,63 @@
         height: 150px;
       }
 
+      .folder-path-badge {
+        font-size: 16px;
+        flex: 0 0 auto;
+        cursor: default;
+      }
+
+      .folder-rule-row {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 8px;
+        align-items: center;
+      }
+
+      .folder-rule-row input {
+        flex: 1;
+        padding: 6px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+      }
+
+      .folder-rule-row .description-input {
+        flex: 2;
+      }
+
+      .remove-rule-btn {
+        padding: 4px 10px;
+        background-color: #dc3545;
+        font-size: 12px;
+        margin-bottom: 0;
+      }
+
+      .remove-rule-btn:hover {
+        background-color: #a71d2a;
+      }
+
+      #add-folder-rule-btn {
+        background-color: #28a745;
+        padding: 6px 12px;
+        font-size: 13px;
+        margin-top: 4px;
+      }
+
+      #add-folder-rule-btn:hover {
+        background-color: #1e7e34;
+      }
+
+      .folder-rule-header {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 4px;
+        font-size: 12px;
+        color: #555;
+      }
+
+      .folder-rule-header span:first-child { flex: 1; }
+      .folder-rule-header span:last-child { flex: 2; }
+
       @-webkit-keyframes fadein {
         from {
           bottom: 0;
@@ -162,6 +219,35 @@
               </sup>
             </label>
           </div>
+        </div>
+
+        <div class="settings-section">
+          <h2>Organise Folder</h2>
+          <p style="font-size:13px;color:#555;margin-bottom:8px;">
+            Define folders and descriptions so the LLM can organise emails and move them automatically.
+            Emails that do not clearly match any folder are kept in place.
+          </p>
+          <div class="folder-rule-header">
+            <span>Folder path</span>
+            <span></span><!-- badge column -->
+            <span>Description for the LLM</span>
+          </div>
+          <div id="folder-rules-list"></div>
+          <button type="button" id="add-folder-rule-btn">+ Add Rule</button>
+
+          <details style="margin-top:12px;">
+            <summary style="cursor:pointer;font-size:13px;color:#333;">
+              Available folder paths
+              <button type="button" id="refresh-folder-paths-btn"
+                style="margin-left:10px;padding:2px 8px;font-size:12px;margin-bottom:0;">
+                ↺ Refresh
+              </button>
+            </summary>
+            <p id="folder-paths-status" style="font-size:12px;color:#555;margin:4px 0;"></p>
+            <pre id="available-folder-paths"
+              style="font-size:12px;background:#f5f5f5;padding:8px;border-radius:4px;
+                     max-height:200px;overflow-y:auto;white-space:pre-wrap;"></pre>
+          </details>
         </div>
 
         <div class="settings-section">

--- a/src/__tests__/emailOrganising.test.ts
+++ b/src/__tests__/emailOrganising.test.ts
@@ -1,0 +1,317 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { timedNotificationMock } = vi.hoisted(() => ({
+  timedNotificationMock: vi.fn(),
+}));
+
+const { sendContentToLlmMock } = vi.hoisted(() => ({
+  sendContentToLlmMock: vi.fn(),
+}));
+
+vi.mock("../llmConnection", () => ({
+  LlmRoles: {
+    SYSTEM: "system",
+    USER: "user",
+  },
+  sendContentToLlm: sendContentToLlmMock,
+  isLlmTextCompletionResponse: (response: unknown) => {
+    return Boolean(response && typeof response === "object" && "id" in response);
+  },
+}));
+
+vi.mock("../notifications", () => ({
+  timedNotification: timedNotificationMock,
+}));
+
+vi.mock("../optionsParams", async () => {
+  const actual = await vi.importActual<typeof import("../optionsParams")>("../optionsParams");
+  return {
+    ...actual,
+    getPluginOptions: vi.fn(async () => ({
+      ...actual.DEFAULT_OPTIONS,
+      folderSortingRules: [{ folderPath: "/target", description: "Target folder" }],
+    })),
+  };
+});
+
+import { organiseCurrentFolder } from "../emailOrganising";
+
+const originalBrowser = global.browser;
+
+describe("emailOrganising", () => {
+  beforeEach(() => {
+    timedNotificationMock.mockReset();
+    sendContentToLlmMock.mockReset();
+  });
+
+  afterAll(() => {
+    global.browser = originalBrowser;
+  });
+
+  test("uses displayed folder id when listing messages", async () => {
+    const messagesList = vi.fn().mockResolvedValue({ id: undefined, messages: [] });
+
+    global.browser = {
+      accounts: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: "acc-1",
+            rootFolder: { accountId: "acc-1", path: "/target", name: "target" },
+          },
+        ]),
+      },
+      mailTabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            displayedFolder: { id: "folder-id", accountId: "acc-1", path: "/inbox", name: "Inbox" },
+          },
+        ]),
+      },
+      messages: {
+        list: messagesList,
+        continueList: vi.fn(),
+        getFull: vi.fn(),
+        move: vi.fn(),
+      },
+      folders: {
+        getSubFolders: vi.fn(),
+      },
+    } as unknown as typeof browser;
+
+    await organiseCurrentFolder(new AbortController().signal);
+
+    expect(messagesList).toHaveBeenCalledTimes(1);
+    expect(messagesList).toHaveBeenCalledWith("folder-id");
+    expect(timedNotificationMock).toHaveBeenCalledWith(
+      "Organise Folder",
+      "The folder is empty — nothing to organise.",
+      5000,
+    );
+  });
+
+  test("falls back to MailFolder object when messages.list rejects folder id", async () => {
+    const messagesList = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Incorrect argument types for messages.list."))
+      .mockResolvedValue({ id: undefined, messages: [] });
+
+    global.browser = {
+      accounts: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: "acc-1",
+            rootFolder: { accountId: "acc-1", path: "/target", name: "target" },
+          },
+        ]),
+      },
+      mailTabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            displayedFolder: { id: "folder-id", accountId: "acc-1", path: "/inbox", name: "Inbox" },
+          },
+        ]),
+      },
+      messages: {
+        list: messagesList,
+        continueList: vi.fn(),
+        getFull: vi.fn(),
+        move: vi.fn(),
+      },
+      folders: {
+        getSubFolders: vi.fn(),
+      },
+    } as unknown as typeof browser;
+
+    await organiseCurrentFolder(new AbortController().signal);
+
+    expect(messagesList).toHaveBeenCalledTimes(2);
+    expect(messagesList).toHaveBeenNthCalledWith(1, "folder-id");
+    expect(messagesList).toHaveBeenNthCalledWith(2, { accountId: "acc-1", path: "/inbox", name: "Inbox" });
+  });
+
+  test("moves classified messages and falls back when messages.move rejects folder id", async () => {
+    const messagesMove = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Incorrect argument types for messages.move."))
+      .mockResolvedValue(undefined);
+
+    sendContentToLlmMock.mockResolvedValue({
+      status: 1,
+      id: "mock-response-id",
+      created: 1,
+      model: "mock-model",
+      choices: [
+        {
+          message: {
+            role: "system",
+            content: '{"classifications":[{"id":15,"folder":1}]}',
+          },
+        },
+      ],
+    });
+
+    global.browser = {
+      accounts: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: "acc-1",
+            rootFolder: { id: "root-id", accountId: "acc-1", path: "/", name: "root" },
+            folders: [{ id: "target-id", accountId: "acc-1", path: "/target", name: "Target" }],
+          },
+        ]),
+      },
+      mailTabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            displayedFolder: { id: "folder-id", accountId: "acc-1", path: "/inbox", name: "Inbox" },
+          },
+        ]),
+      },
+      messages: {
+        list: vi.fn().mockResolvedValue({
+          id: undefined,
+          messages: [{ id: 15, author: "alice@example.com", subject: "Quarterly report" }],
+        }),
+        continueList: vi.fn(),
+        getFull: vi.fn().mockResolvedValue({ contentType: "text/plain", body: "Please process this message" }),
+        move: messagesMove,
+      },
+      folders: {
+        getSubFolders: vi.fn(),
+      },
+    } as unknown as typeof browser;
+
+    await organiseCurrentFolder(new AbortController().signal);
+
+    expect(messagesMove).toHaveBeenCalledTimes(2);
+    expect(messagesMove).toHaveBeenNthCalledWith(1, [15], "target-id");
+    expect(messagesMove).toHaveBeenNthCalledWith(2, [15], {
+      accountId: "acc-1",
+      path: "/target",
+      name: "Target",
+    });
+    expect(timedNotificationMock).toHaveBeenCalledWith(
+      "Organise Folder Complete",
+      "Moved 1 email(s). 0 email(s) kept in place.",
+      10000,
+    );
+  });
+
+  test("parses and applies classifications when LLM reply includes think-tag prose before JSON", async () => {
+    const messagesMove = vi.fn().mockResolvedValue(undefined);
+
+    sendContentToLlmMock.mockResolvedValue({
+      status: 1,
+      id: "mock-response-id",
+      created: 1,
+      model: "mock-model",
+      choices: [
+        {
+          message: {
+            role: "system",
+            content:
+              '<think>So, summarizing the emails that are introductions (folder 1):\n- ID 8: Leander Blume\n- ID 7: Matthias Weber\n\nAll others: null.</think>\n{"classifications":[{"id":8,"folder":1},{"id":7,"folder":1}]}',
+          },
+        },
+      ],
+    });
+
+    global.browser = {
+      accounts: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: "acc-1",
+            rootFolder: { id: "root-id", accountId: "acc-1", path: "/", name: "root" },
+            folders: [{ id: "target-id", accountId: "acc-1", path: "/target", name: "Target" }],
+          },
+        ]),
+      },
+      mailTabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            displayedFolder: { id: "folder-id", accountId: "acc-1", path: "/inbox", name: "Inbox" },
+          },
+        ]),
+      },
+      messages: {
+        list: vi.fn().mockResolvedValue({
+          id: undefined,
+          messages: [
+            { id: 8, author: "alice@example.com", subject: "Intro 1" },
+            { id: 7, author: "bob@example.com", subject: "Intro 2" },
+          ],
+        }),
+        continueList: vi.fn(),
+        getFull: vi.fn().mockResolvedValue({ contentType: "text/plain", body: "Message body" }),
+        move: messagesMove,
+      },
+      folders: {
+        getSubFolders: vi.fn(),
+      },
+    } as unknown as typeof browser;
+
+    await organiseCurrentFolder(new AbortController().signal);
+
+    expect(messagesMove).toHaveBeenCalledTimes(2);
+    expect(messagesMove).toHaveBeenNthCalledWith(1, [8], "target-id");
+    expect(messagesMove).toHaveBeenNthCalledWith(2, [7], "target-id");
+    expect(timedNotificationMock).toHaveBeenCalledWith(
+      "Organise Folder Complete",
+      "Moved 2 email(s). 0 email(s) kept in place.",
+      10000,
+    );
+  });
+
+  test("keeps messages in place when LLM response has no choice message content", async () => {
+    const messagesMove = vi.fn().mockResolvedValue(undefined);
+
+    sendContentToLlmMock.mockResolvedValue({
+      status: 1,
+      id: "mock-response-id",
+      created: 1,
+      model: "mock-model",
+      choices: [],
+    });
+
+    global.browser = {
+      accounts: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: "acc-1",
+            rootFolder: { id: "root-id", accountId: "acc-1", path: "/", name: "root" },
+            folders: [{ id: "target-id", accountId: "acc-1", path: "/target", name: "Target" }],
+          },
+        ]),
+      },
+      mailTabs: {
+        query: vi.fn().mockResolvedValue([
+          {
+            displayedFolder: { id: "folder-id", accountId: "acc-1", path: "/inbox", name: "Inbox" },
+          },
+        ]),
+      },
+      messages: {
+        list: vi.fn().mockResolvedValue({
+          id: undefined,
+          messages: [{ id: 15, author: "alice@example.com", subject: "Quarterly report" }],
+        }),
+        continueList: vi.fn(),
+        getFull: vi.fn().mockResolvedValue({ contentType: "text/plain", body: "Please process this message" }),
+        move: messagesMove,
+      },
+      folders: {
+        getSubFolders: vi.fn(),
+      },
+    } as unknown as typeof browser;
+
+    await organiseCurrentFolder(new AbortController().signal);
+
+    expect(messagesMove).not.toHaveBeenCalled();
+    expect(timedNotificationMock).toHaveBeenCalledWith(
+      "Organise Folder Complete",
+      "Moved 0 email(s). 1 email(s) kept in place.",
+      10000,
+    );
+  });
+});
+

--- a/src/__tests__/emailOrganising.test.ts
+++ b/src/__tests__/emailOrganising.test.ts
@@ -314,4 +314,3 @@ describe("emailOrganising", () => {
     );
   });
 });
-

--- a/src/background.ts
+++ b/src/background.ts
@@ -28,6 +28,7 @@ browser.menus.onClicked.addListener(handleMenuClickListener);
 // Thunderbird MV3 uses browser.action; guard in case the API is not available.
 const organiseAbortControllers = new Map<number, AbortController>();
 
+/** Get clicked tab ID, falling back to active tab if none provided. */
 async function resolveClickedTabId(tab?: Tab): Promise<number | undefined> {
   if (tab?.id !== undefined) {
     return tab.id;
@@ -38,6 +39,7 @@ async function resolveClickedTabId(tab?: Tab): Promise<number | undefined> {
   return activeTabs[0]?.id;
 }
 
+/** Update compose action icon and title to reflect loading/idle state. */
 async function setOrganiseActionState(loading: boolean) {
   try {
     if (loading) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,8 @@
+import { getAllFolderPaths, organiseCurrentFolder } from "./emailOrganising";
 import { handleKeepAliveAlarm } from "./keepAlive";
 import { executeLlmAction, type LlmPluginAction } from "./llmButtonClickHandling";
 import { addLlmActionsToMenu, enableSummarizeMenuEntryIfReply, handleMenuClickListener } from "./menu";
+import { notifyOnError, timedNotification } from "./notifications";
 import { deleteFromOriginalTabCache, storeOriginalReplyText } from "./originalTabConversation";
 
 import Tab = browser.tabs.Tab;
@@ -20,7 +22,99 @@ browser.tabs.onCreated.addListener(async (tab: Tab) => {
 });
 
 browser.tabs.onRemoved.addListener(deleteFromOriginalTabCache);
-
 browser.menus.onClicked.addListener(handleMenuClickListener);
 
-await addLlmActionsToMenu();
+// ── Organise-folder action (shown in mail tabs) ───────────────────────────────
+// Thunderbird MV3 uses browser.action; guard in case the API is not available.
+const organiseAbortControllers = new Map<number, AbortController>();
+
+async function resolveClickedTabId(tab?: Tab): Promise<number | undefined> {
+  if (tab?.id !== undefined) {
+    return tab.id;
+  }
+
+  // Thunderbird may invoke action clicks without a tab payload in some contexts.
+  const activeTabs = await browser.tabs.query({ active: true, currentWindow: true });
+  return activeTabs[0]?.id;
+}
+
+async function setOrganiseActionState(loading: boolean) {
+  try {
+    if (loading) {
+      await browser.action.setTitle({ title: "Cancel Organise Folder (click to stop)" });
+      await browser.action.setIcon({ path: { 32: "icons/loader-32px.gif" } });
+    } else {
+      await browser.action.setTitle({ title: "Organise Folder with LLM (dev)" });
+      await browser.action.setIcon({
+        path: { 16: "icons/icon-16px.png", 32: "icons/icon-32px.png", 64: "icons/icon-64px.png" },
+      });
+    }
+  } catch (e) {
+    console.warn("ORGANISE: Could not update action icon/title:", e);
+  }
+}
+
+if (browser.action?.onClicked) {
+  console.log("ORGANISE: Registering browser.action.onClicked listener");
+  browser.action.onClicked.addListener(async (tab?: Tab) => {
+    console.log("ORGANISE: Action button clicked, tab:", tab?.id);
+    const tabId = await resolveClickedTabId(tab);
+    if (tabId === undefined) {
+      console.error("ORGANISE: No tabId on click");
+      await timedNotification(
+        "LLM Composer",
+        "Could not detect the active tab for organise folder. Please click the button in a mail tab.",
+        7000,
+      );
+      return;
+    }
+
+    // Second click = cancel
+    if (organiseAbortControllers.has(tabId)) {
+      console.log("ORGANISE: Aborting existing organise-folder run for tab", tabId);
+      organiseAbortControllers.get(tabId)?.abort(new DOMException("User cancelled organise folder", "AbortError"));
+      organiseAbortControllers.delete(tabId);
+      await setOrganiseActionState(false);
+      return;
+    }
+
+    const abortController = new AbortController();
+    organiseAbortControllers.set(tabId, abortController);
+    await setOrganiseActionState(true);
+
+    await notifyOnError(async () => {
+      try {
+        await organiseCurrentFolder(abortController.signal);
+      } finally {
+        organiseAbortControllers.delete(tabId);
+        await setOrganiseActionState(false);
+      }
+    });
+  });
+} else {
+  console.error("ORGANISE: browser.action.onClicked is not available in this Thunderbird version.");
+  timedNotification("LLM Composer", "Organise folder button requires Thunderbird 128 or later.", 10000);
+}
+
+// Register menu entries without blocking listener registration; this keeps
+// click handlers responsive when MV3 wakes the background script on demand.
+void addLlmActionsToMenu().catch((e) => {
+  console.error("BACKGROUND: Failed to add LLM actions to menu:", e);
+});
+
+type RuntimeRequestMessage = {
+  type: "get-folder-paths";
+};
+
+function isRuntimeRequestMessage(value: unknown): value is RuntimeRequestMessage {
+  if (!value || typeof value !== "object") return false;
+  return (value as { type?: unknown }).type === "get-folder-paths";
+}
+
+// Handle options-page requests that need background-context APIs.
+browser.runtime.onMessage.addListener((message: unknown) => {
+  if (!isRuntimeRequestMessage(message)) {
+    return false;
+  }
+  return getAllFolderPaths();
+});

--- a/src/emailOrganising.ts
+++ b/src/emailOrganising.ts
@@ -1,0 +1,440 @@
+import { isLlmTextCompletionResponse, LlmRoles, sendContentToLlm } from "./llmConnection";
+import { timedNotification } from "./notifications";
+import { type FolderRule, getPluginOptions } from "./optionsParams";
+import { stripHtml } from "./utils";
+
+const BATCH_ORGANISING_SYSTEM_PROMPT = `You are an email organisation assistant.
+You will be given:
+- A numbered list of folder categories with descriptions
+- Multiple emails, each with a stable numeric id
+
+Organise each email into exactly one folder index (1-based), or null when no folder fits.
+
+Respond with JSON only in this exact shape:
+{"classifications":[{"id":123,"folder":1},{"id":124,"folder":null}]}
+
+Rules:
+- Use only folder indexes that exist in the provided folder list
+- Keep every provided id exactly once in the output
+- No markdown, no prose, no code fences.`;
+
+const MAX_EMAIL_BODY_CHARS = 1200;
+const BATCH_SIZE = 15;
+
+type MessageForOrganising = {
+  message: browser.messages.MessageHeader;
+  refId: number;
+  sender: string;
+  subject: string;
+  body: string;
+};
+
+function buildBatchOrganisingPrompt(rules: FolderRule[], messages: MessageForOrganising[]): string {
+  const folderList = rules.map((rule, index) => `${index + 1}. ${rule.folderPath} — ${rule.description}`).join("\n");
+  const emailBlocks = messages
+    .map(
+      (entry) =>
+        `ID: ${entry.refId}\nFrom: ${entry.sender}\nSubject: ${entry.subject}\nBody:\n${entry.body.slice(0, MAX_EMAIL_BODY_CHARS)}`,
+    )
+    .join("\n\n-----\n\n");
+  return `Folders:\n${folderList}\n\nEmails:\n${emailBlocks}`;
+}
+
+function chunk<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let start = 0; start < items.length; start += chunkSize) {
+    chunks.push(items.slice(start, start + chunkSize));
+  }
+  return chunks;
+}
+
+function parseBatchOrganisingResponse(
+  rawResponse: string,
+  expectedIds: number[],
+  rulesCount: number,
+): Map<number, number | null> {
+  const result = new Map<number, number | null>(expectedIds.map((id) => [id, null]));
+  const parseInput = extractJsonObject(rawResponse);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(parseInput);
+  } catch {
+    return result;
+  }
+
+  const organisationDecisions =
+    parsed && typeof parsed === "object" && "classifications" in parsed
+      ? (parsed as { classifications?: unknown }).classifications
+      : undefined;
+
+  if (!Array.isArray(organisationDecisions)) {
+    return result;
+  }
+
+  for (const item of organisationDecisions) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    const maybeId = (item as { id?: unknown }).id;
+    if (typeof maybeId !== "number" || !result.has(maybeId)) {
+      continue;
+    }
+
+    const maybeFolder = (item as { folder?: unknown }).folder;
+    if (maybeFolder === null || maybeFolder === "NONE") {
+      result.set(maybeId, null);
+      continue;
+    }
+
+    if (typeof maybeFolder === "number" && maybeFolder >= 1 && maybeFolder <= rulesCount) {
+      result.set(maybeId, maybeFolder - 1);
+    }
+  }
+
+  return result;
+}
+
+function extractJsonObject(raw: string): string {
+  const trimmed = raw.trim();
+
+  const withoutThinkTags = trimmed
+    .replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, "")
+    .replace(/<think\b[^>]*>[\s\S]*$/gi, "")
+    .trim();
+
+  if (withoutThinkTags.startsWith("{")) {
+    return withoutThinkTags;
+  }
+
+  const codeFenceMatch = withoutThinkTags.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (codeFenceMatch?.[1]) {
+    return codeFenceMatch[1].trim();
+  }
+
+  const firstBrace = withoutThinkTags.indexOf("{");
+  const lastBrace = withoutThinkTags.lastIndexOf("}");
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    return withoutThinkTags.slice(firstBrace, lastBrace + 1).trim();
+  }
+
+  return withoutThinkTags;
+}
+
+async function getFoldersForAccount(account: browser.accounts.MailAccount): Promise<browser.folders.MailFolder[]> {
+  // In MV3, accounts.list() may omit account.folders; fetch folder tree via folders API.
+  if (account.folders && account.folders.length > 0) {
+    return account.folders;
+  }
+  // browser.folders.getSubFolders expects a MailFolder (the account's root folder),
+  // not the MailAccount object itself — passing the account throws
+  // "Incorrect argument types for folders.getSubFolders".
+  const rootFolder = account.rootFolder;
+  if (!rootFolder) {
+    return [];
+  }
+  // Prefer the canonical MailFolderId string when available. In recent
+  // Thunderbird versions the rootFolder object returned by accounts.list()
+  // may not validate against the MailFolder schema expected by
+  // getSubFolders (causing "Incorrect argument types"), whereas the plain
+  // id string is always accepted. Fall back to the object for older builds.
+  const folderRef = rootFolder.id ?? rootFolder;
+  try {
+    return await browser.folders.getSubFolders(folderRef, true);
+  } catch (e) {
+    console.warn("ORGANISE: Could not read folders for account", account.id, e);
+    return [];
+  }
+}
+
+/** Resolve a folderPath string like "/INBOX/Work" to a MailFolder object. */
+async function resolveFolderPath(folderPath: string): Promise<browser.folders.MailFolder | null> {
+  const accounts = await browser.accounts.list(true);
+  for (const account of accounts) {
+    const foundInRoot = account.rootFolder?.path === folderPath ? account.rootFolder : null;
+    if (foundInRoot) return foundInRoot;
+
+    const accountFolders = await getFoldersForAccount(account);
+    const found = findFolderInTree(accountFolders, folderPath);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findFolderInTree(folders: browser.folders.MailFolder[], path: string): browser.folders.MailFolder | null {
+  for (const folder of folders) {
+    if (folder.path === path) return folder;
+    const sub = findFolderInTree(folder.subFolders ?? [], path);
+    if (sub) return sub;
+  }
+  return null;
+}
+
+/** Return a flat list of all folder paths across all accounts (for diagnostics / options UI). */
+export async function getAllFolderPaths(): Promise<string[]> {
+  const accounts = await browser.accounts.list(true);
+  const paths = new Set<string>();
+
+  for (const account of accounts) {
+    if (account.rootFolder?.path) {
+      paths.add(account.rootFolder.path);
+    }
+    collectPaths(await getFoldersForAccount(account), paths);
+  }
+
+  return Array.from(paths);
+}
+
+function collectPaths(folders: browser.folders.MailFolder[], out: Set<string>) {
+  for (const f of folders) {
+    out.add(f.path);
+    collectPaths(f.subFolders ?? [], out);
+  }
+}
+
+function isIncorrectMessagesListArgumentError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Incorrect argument types for messages.list");
+}
+
+function isIncorrectMessagesMoveArgumentError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Incorrect argument types for messages.move");
+}
+
+async function listFolderMessages(
+  displayedFolder: browser.folders.MailFolder,
+): Promise<Awaited<ReturnType<typeof browser.messages.list>>> {
+  const folderWithId = displayedFolder as browser.folders.MailFolder & { id?: string };
+
+  // In newer Thunderbird builds, messages.list is more reliable when using the
+  // canonical folder id string instead of a MailFolder object.
+  if (folderWithId.id) {
+    try {
+      return await browser.messages.list(folderWithId.id as unknown as browser.folders.MailFolder);
+    } catch (error) {
+      if (!isIncorrectMessagesListArgumentError(error)) {
+        throw error;
+      }
+      console.warn("ORGANISE: messages.list rejected folder id, retrying with MailFolder object", error);
+    }
+  }
+
+  if (!displayedFolder.accountId || !displayedFolder.path) {
+    throw new Error("Could not resolve the currently displayed folder.");
+  }
+
+  // Build a minimal serialisable MailFolder shape for strict schema validation.
+  const folderObject: browser.folders.MailFolder = {
+    accountId: displayedFolder.accountId,
+    path: displayedFolder.path,
+    name: displayedFolder.name ?? displayedFolder.path,
+  };
+
+  return browser.messages.list(folderObject);
+}
+
+async function moveMessageToFolder(messageId: number, targetFolder: browser.folders.MailFolder): Promise<void> {
+  const folderWithId = targetFolder as browser.folders.MailFolder & { id?: string };
+  if (folderWithId.id) {
+    try {
+      await browser.messages.move([messageId], folderWithId.id as unknown as browser.folders.MailFolder);
+      return;
+    } catch (error) {
+      if (!isIncorrectMessagesMoveArgumentError(error)) {
+        throw error;
+      }
+      console.warn("ORGANISE: messages.move rejected folder id, retrying with MailFolder object", error);
+    }
+  }
+
+  const fallbackFolder: browser.folders.MailFolder = {
+    accountId: targetFolder.accountId,
+    path: targetFolder.path,
+    name: targetFolder.name,
+  };
+  await browser.messages.move([messageId], fallbackFolder);
+}
+
+export async function organiseCurrentFolder(abortSignal: AbortSignal): Promise<void> {
+  const options = await getPluginOptions();
+  const rules = options.folderSortingRules ?? [];
+
+  if (rules.length === 0) {
+    throw new Error("No folder organisation rules configured. Please add rules in the extension options.");
+  }
+
+  // Resolve destination folders up front so we can warn early about bad paths.
+  const resolvedFolders: Array<browser.folders.MailFolder | null> = await Promise.all(
+    rules.map((r: FolderRule) => resolveFolderPath(r.folderPath)),
+  );
+
+  const unresolvedPaths = rules
+    .filter((_: FolderRule, i: number) => resolvedFolders[i] === null)
+    .map((r: FolderRule) => r.folderPath);
+  if (unresolvedPaths.length > 0) {
+    const available = await getAllFolderPaths();
+    console.warn("ORGANISE: Could not resolve folder paths:", unresolvedPaths);
+    console.info("ORGANISE: Available folder paths:", available);
+    throw new Error(
+      `Could not find these folder paths: ${unresolvedPaths.join(", ")}\n\n` +
+        `Available paths:\n${available.join("\n")}\n\n` +
+        `Please update your folder organisation rules in the extension options.`,
+    );
+  }
+
+  // Get active mail tab and its current folder.
+  const mailTabs = await browser.mailTabs.query({ active: true, currentWindow: true });
+  const mailTab = mailTabs[0];
+  if (!mailTab?.displayedFolder) {
+    throw new Error("No folder is currently displayed. Open a mail folder first.");
+  }
+
+  const sourceFolder = mailTab.displayedFolder;
+  console.log("ORGANISE: displayedFolder raw:", JSON.stringify(sourceFolder));
+
+  // Collect all messages (the API pages results).
+  const allMessages: browser.messages.MessageHeader[] = [];
+  let page = await listFolderMessages(sourceFolder);
+  allMessages.push(...page.messages);
+  while (page.id) {
+    page = await browser.messages.continueList(page.id);
+    allMessages.push(...page.messages);
+  }
+
+  if (allMessages.length === 0) {
+    await timedNotification("Organise Folder", "The folder is empty — nothing to organise.", 5000);
+    return;
+  }
+
+  const messagesForOrganising: MessageForOrganising[] = await Promise.all(
+    allMessages.map(async (msg, index) => {
+      let body = "";
+      try {
+        if (msg.id !== undefined) {
+          const full = await browser.messages.getFull(msg.id);
+          body = extractTextFromPart(full);
+        }
+      } catch {
+        body = "";
+      }
+
+      return {
+        message: msg,
+        refId: msg.id ?? -(index + 1),
+        sender: msg.author ?? "",
+        subject: msg.subject ?? "(no subject)",
+        body,
+      };
+    }),
+  );
+
+  const organisationByRefId = new Map<number, number | null>();
+  for (const entriesChunk of chunk(messagesForOrganising, BATCH_SIZE)) {
+    if (abortSignal.aborted) break;
+
+    const userPrompt = buildBatchOrganisingPrompt(rules, entriesChunk);
+    try {
+      const response = await sendContentToLlm(
+        [
+          { role: LlmRoles.SYSTEM, content: BATCH_ORGANISING_SYSTEM_PROMPT },
+          { role: LlmRoles.USER, content: userPrompt },
+        ],
+        abortSignal,
+      );
+
+      if (!isLlmTextCompletionResponse(response)) {
+        console.warn("ORGANISE: LLM error response for batch", response);
+        for (const entry of entriesChunk) {
+          organisationByRefId.set(entry.refId, null);
+        }
+        continue;
+      }
+
+      const firstChoice = Array.isArray(response.choices) ? response.choices[0] : undefined;
+      const rawBatchResponse =
+        firstChoice && typeof firstChoice.message?.content === "string" ? firstChoice.message.content : null;
+      if (rawBatchResponse === null) {
+        console.error("ORGANISE: LLM batch response missing choices[0].message.content", response);
+        for (const entry of entriesChunk) {
+          organisationByRefId.set(entry.refId, null);
+        }
+        continue;
+      }
+      console.log("ORGANISE: LLM batch reply:", rawBatchResponse);
+
+      const parsed = parseBatchOrganisingResponse(
+        rawBatchResponse,
+        entriesChunk.map((entry) => entry.refId),
+        rules.length,
+      );
+      for (const [refId, ruleIndex] of parsed.entries()) {
+        organisationByRefId.set(refId, ruleIndex);
+      }
+    } catch (e) {
+      if ((e as Error).name === "AbortError") throw e;
+      console.warn("ORGANISE: LLM call failed for batch", e);
+      for (const entry of entriesChunk) {
+        organisationByRefId.set(entry.refId, null);
+      }
+    }
+  }
+
+  let moved = 0;
+  let skipped = 0;
+
+  for (const entry of messagesForOrganising) {
+    if (abortSignal.aborted) break;
+
+    const responseIndex = organisationByRefId.get(entry.refId) ?? null;
+    if (responseIndex === null) {
+      skipped++;
+      continue;
+    }
+
+    const targetFolder = resolvedFolders[responseIndex];
+    if (!targetFolder) {
+      console.warn(
+        `ORGANISE: Target folder not found for rule "${rules[responseIndex].folderPath}" — keeping in place`,
+      );
+      skipped++;
+      continue;
+    }
+
+    if (entry.message.id === undefined) {
+      console.warn(`ORGANISE: Message without id cannot be moved (subject: "${entry.subject}")`);
+      skipped++;
+      continue;
+    }
+
+    try {
+      await moveMessageToFolder(entry.message.id, targetFolder);
+      moved++;
+      console.log(`ORGANISE: Moved "${entry.subject}" -> ${rules[responseIndex].folderPath}`);
+    } catch (e) {
+      console.warn("ORGANISE: Failed to move message", entry.message.id, e);
+      skipped++;
+    }
+  }
+
+  await timedNotification(
+    "Organise Folder Complete",
+    `Moved ${moved} email(s). ${skipped} email(s) kept in place.`,
+    10000,
+  );
+}
+
+function extractTextFromPart(part: browser.messages.MessagePart): string {
+  if (part.contentType === "text/plain" && part.body) {
+    return part.body;
+  }
+  if (part.contentType === "text/html" && part.body) {
+    return stripHtml(part.body);
+  }
+  if (part.parts) {
+    for (const sub of part.parts) {
+      const text = extractTextFromPart(sub);
+      if (text) return text;
+    }
+  }
+  return "";
+}

--- a/src/emailOrganising.ts
+++ b/src/emailOrganising.ts
@@ -48,6 +48,7 @@ function chunk<T>(items: T[], chunkSize: number): T[][] {
   return chunks;
 }
 
+/** Parse LLM classification response and map message IDs to folder indices (0-based, null for unclassified). */
 function parseBatchOrganisingResponse(
   rawResponse: string,
   expectedIds: number[],
@@ -96,6 +97,7 @@ function parseBatchOrganisingResponse(
   return result;
 }
 
+/** Extract JSON object from raw response, stripping think tags and handling markdown code fences. */
 function extractJsonObject(raw: string): string {
   const trimmed = raw.trim();
 
@@ -122,6 +124,7 @@ function extractJsonObject(raw: string): string {
   return withoutThinkTags;
 }
 
+/** Get folder list for account, using folders API if account.folders is unavailable (MV3 quirk). */
 async function getFoldersForAccount(account: browser.accounts.MailAccount): Promise<browser.folders.MailFolder[]> {
   // In MV3, accounts.list() may omit account.folders; fetch folder tree via folders API.
   if (account.folders && account.folders.length > 0) {
@@ -201,6 +204,7 @@ function isIncorrectMessagesMoveArgumentError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("Incorrect argument types for messages.move");
 }
 
+/** List folder messages, trying folder ID first for newer Thunderbird builds, then fallback to MailFolder object. */
 async function listFolderMessages(
   displayedFolder: browser.folders.MailFolder,
 ): Promise<Awaited<ReturnType<typeof browser.messages.list>>> {
@@ -233,6 +237,7 @@ async function listFolderMessages(
   return browser.messages.list(folderObject);
 }
 
+/** Move message to target folder, trying folder ID first, then fallback to MailFolder object. */
 async function moveMessageToFolder(messageId: number, targetFolder: browser.folders.MailFolder): Promise<void> {
   const folderWithId = targetFolder as browser.folders.MailFolder & { id?: string };
   if (folderWithId.id) {
@@ -423,6 +428,7 @@ export async function organiseCurrentFolder(abortSignal: AbortSignal): Promise<v
   );
 }
 
+/** Recursively extract text (plain or stripped HTML) from message part hierarchy. */
 function extractTextFromPart(part: browser.messages.MessagePart): string {
   if (part.contentType === "text/plain" && part.body) {
     return part.body;

--- a/src/llmButtonClickHandling.ts
+++ b/src/llmButtonClickHandling.ts
@@ -69,6 +69,7 @@ export const allRequestsStatus = new AllRequestsStatus();
 
 export type LlmPluginAction = "compose" | "summarize" | "cancel";
 
+/** Execute LLM action with loading state, cancellation support, and error handling. */
 export async function llmActionClickHandler(tab: Tab, communicateWithLlm: (tabID: number) => Promise<void>) {
   const openTabId = tab.id;
   if (!openTabId) {
@@ -79,6 +80,7 @@ export async function llmActionClickHandler(tab: Tab, communicateWithLlm: (tabID
   await withButtonRequestInProgress(openTabId, () => communicateWithLlm(openTabId));
 }
 
+/** Show loading state while executing callback; restore idle state when done. */
 async function withButtonRequestInProgress<T>(tabId: number, callback: () => Promise<T>) {
   const requestStatus = allRequestsStatus.getRequestStatus(tabId);
   requestStatus.isRunning = true;

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -36,6 +36,7 @@ export async function addLlmActionsToMenu() {
 export async function addMenuEntry(createData: browser.menus._CreateCreateProperties) {
   console.log(`MENU: add '${createData.title}' option`);
   type CommandInfo = { name: string; shortcut?: string };
+  // Append keyboard shortcut to menu title if available
   const shortcut = (await browser.commands.getAll())
     .filter((cmd: CommandInfo) => cmd.name === createData.id)
     .map((cmd: CommandInfo) => cmd.shortcut)[0];

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -7,6 +7,7 @@ export async function timedNotification(title: string, message: string, ms = 300
   setTimeout(() => browser.notifications.clear(notificationId), ms);
 }
 
+/** Execute callback, suppressing AbortError silently and showing timed notifications for other errors. */
 export function notifyOnError<T>(callback: () => Promise<T>) {
   return callback().catch((e) => {
     console.debug("Error occurred", e);

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,11 @@
+import { getAllFolderPaths } from "./emailOrganising";
 import { notifyOnError } from "./notifications";
-import { getPluginOptions } from "./optionsParams";
+import { type FolderRule, getPluginOptions } from "./optionsParams";
 import { getInputElement } from "./utils";
+
+type GetFolderPathsMessage = {
+  type: "get-folder-paths";
+};
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.querySelector("#url")?.addEventListener("change", updateUrl);
@@ -11,6 +16,8 @@ document.querySelector("#use_last_mails")?.addEventListener("change", updateUseL
 document.querySelector("#strip_think_tag")?.addEventListener("change", updateStripThinkTag);
 document.querySelector("#context_window")?.addEventListener("change", updateContextWindow);
 document.querySelector("#other_options")?.addEventListener("change", updateOtherOptions);
+document.querySelector("#add-folder-rule-btn")?.addEventListener("click", addFolderRuleRow);
+document.querySelector("#refresh-folder-paths-btn")?.addEventListener("click", refreshFolderPaths);
 
 async function updateUrl(event: Event) {
   await notifyOnError(async () => {
@@ -88,4 +95,165 @@ export async function restoreOptions(): Promise<void> {
   getInputElement("#strip_think_tag").checked = options.strip_think_tag ?? true;
   getInputElement("#other_options").value = JSON.stringify(options.params, null, 2);
   getInputElement("#llm_context").value = options.llmContext;
+
+  const rules = options.folderSortingRules ?? [];
+  const list = document.querySelector("#folder-rules-list");
+  if (!list) return;
+  list.innerHTML = "";
+
+  await refreshFolderPaths();
+
+  const knownPaths = getKnownPaths();
+  for (const rule of rules) {
+    appendFolderRuleRow(rule.folderPath, rule.description, knownPaths);
+  }
+}
+
+// ── Folder path loading ───────────────────────────────────────────────────────
+
+function getKnownPaths(): string[] {
+  const dl = document.querySelector<HTMLDataListElement>("#folder-paths-datalist");
+  return dl ? Array.from(dl.options).map((o) => o.value) : [];
+}
+
+async function refreshFolderPaths() {
+  const statusEl = document.querySelector("#folder-paths-status");
+  const availableEl = document.querySelector("#available-folder-paths");
+  if (statusEl) statusEl.textContent = "Loading folder paths...";
+  if (availableEl) availableEl.textContent = "";
+
+  try {
+    const paths = await loadFolderPaths();
+
+    // Populate datalist for autocomplete
+    let dl = document.querySelector<HTMLDataListElement>("#folder-paths-datalist");
+    if (!dl) {
+      dl = document.createElement("datalist");
+      dl.id = "folder-paths-datalist";
+      document.body.appendChild(dl);
+    }
+    dl.innerHTML = paths.map((p) => `<option value="${p}"></option>`).join("");
+
+    if (statusEl) statusEl.textContent = `${paths.length} folder(s) found.`;
+    if (availableEl) availableEl.textContent = paths.join("\n");
+
+    // Re-validate any existing rows
+    revalidateAllRows(paths);
+  } catch (e) {
+    console.error("OPTIONS: Could not fetch folder paths:", e);
+    if (statusEl) statusEl.textContent = `Could not load folder paths: ${(e as Error).message}`;
+  }
+}
+
+async function loadFolderPaths(): Promise<string[]> {
+  try {
+    return await getAllFolderPaths();
+  } catch (directError) {
+    console.warn("OPTIONS: Direct folder-path lookup failed, trying background fallback:", directError);
+  }
+
+  const response = await browser.runtime.sendMessage({ type: "get-folder-paths" } as GetFolderPathsMessage);
+  if (!Array.isArray(response) || response.some((path) => typeof path !== "string")) {
+    throw new Error("Invalid folder path response from background script.");
+  }
+  return response;
+}
+
+function revalidateAllRows(knownPaths: string[]) {
+  for (const row of document.querySelectorAll<HTMLDivElement>(".folder-rule-row")) {
+    const pathInput = row.querySelector<HTMLInputElement>("input");
+    const badge = row.querySelector<HTMLSpanElement>(".folder-path-badge");
+    if (pathInput && badge) applyBadge(badge, pathInput.value.trim(), knownPaths);
+  }
+}
+
+// ── Organise-folder rules ──────────────────────────────────────────────────────
+
+function applyBadge(badge: HTMLSpanElement, val: string, knownPaths: string[]) {
+  if (!val) {
+    badge.textContent = "";
+    badge.title = "";
+  } else if (knownPaths.length === 0) {
+    badge.textContent = "⏳";
+    badge.title = "Folder list not yet loaded";
+  } else if (knownPaths.includes(val)) {
+    badge.textContent = "✅";
+    badge.title = "Folder found";
+  } else {
+    badge.textContent = "⚠️";
+    badge.title = `Path not found in your mailbox.\nCheck the "Available folder paths" list below.`;
+  }
+}
+
+function appendFolderRuleRow(folderPath = "", description = "", knownPaths: string[] = []) {
+  const list = document.querySelector("#folder-rules-list");
+  if (!list) return;
+  const row = document.createElement("div");
+  row.className = "folder-rule-row";
+
+  const pathInput = document.createElement("input");
+  pathInput.type = "text";
+  pathInput.setAttribute("list", "folder-paths-datalist");
+  pathInput.placeholder = "/INBOX/Work";
+  pathInput.value = folderPath;
+
+  const badge = document.createElement("span");
+  badge.className = "folder-path-badge";
+  applyBadge(badge, folderPath, knownPaths);
+
+  pathInput.addEventListener("input", () => {
+    applyBadge(badge, pathInput.value.trim(), getKnownPaths());
+  });
+  pathInput.addEventListener("change", () => {
+    applyBadge(badge, pathInput.value.trim(), getKnownPaths());
+    saveFolderRules();
+  });
+
+  const descInput = document.createElement("input");
+  descInput.type = "text";
+  descInput.className = "description-input";
+  descInput.placeholder = "Emails about work projects";
+  descInput.value = description;
+  descInput.addEventListener("change", saveFolderRules);
+
+  const removeBtn = document.createElement("button");
+  removeBtn.type = "button";
+  removeBtn.className = "remove-rule-btn";
+  removeBtn.textContent = "✕";
+  removeBtn.addEventListener("click", () => {
+    row.remove();
+    saveFolderRules();
+  });
+
+  row.appendChild(pathInput);
+  row.appendChild(badge);
+  row.appendChild(descInput);
+  row.appendChild(removeBtn);
+  list.appendChild(row);
+}
+
+function addFolderRuleRow() {
+  appendFolderRuleRow("", "", getKnownPaths());
+}
+
+function collectFolderRules(): FolderRule[] {
+  const rows = document.querySelectorAll<HTMLDivElement>(".folder-rule-row");
+  const rules: FolderRule[] = [];
+  for (const row of rows) {
+    const inputs = row.querySelectorAll<HTMLInputElement>("input");
+    const folderPath = inputs[0]?.value.trim() ?? "";
+    const description = inputs[1]?.value.trim() ?? "";
+    if (folderPath) {
+      rules.push({ folderPath, description });
+    }
+  }
+  return rules;
+}
+
+async function saveFolderRules() {
+  await notifyOnError(async () => {
+    const options = await getPluginOptions();
+    options.folderSortingRules = collectFolderRules();
+    await browser.storage.sync.set({ options });
+  });
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -132,7 +132,13 @@ async function refreshFolderPaths() {
       dl.id = "folder-paths-datalist";
       document.body.appendChild(dl);
     }
-    dl.innerHTML = paths.map((p) => `<option value="${p}"></option>`).join("");
+    dl.replaceChildren();
+    for (const path of paths) {
+      const option = document.createElement("option");
+      option.value = path;
+      option.textContent = path;
+      dl.appendChild(option);
+    }
 
     if (statusEl) statusEl.textContent = `${paths.length} folder(s) found.`;
     if (availableEl) availableEl.textContent = paths.join("\n");

--- a/src/optionsParams.ts
+++ b/src/optionsParams.ts
@@ -16,6 +16,11 @@ export interface LlmParameters {
   logprobs?: number;
 }
 
+export interface FolderRule {
+  folderPath: string; // e.g. "/INBOX/Work"
+  description: string; // free-text description for the LLM
+}
+
 export interface Options {
   model: string;
   api_token?: string;
@@ -25,6 +30,7 @@ export interface Options {
   params: LlmParameters;
   llmContext: string;
   timeout?: number; // Timeout in milliseconds, undefined means no timeout
+  folderSortingRules: FolderRule[];
 }
 
 export const DEFAULT_PARAMS: LlmParameters = {};
@@ -43,6 +49,7 @@ export const DEFAULT_OPTIONS: Options = {
     "[Salutation]\n" +
     "[Writer's name, without the mail signature]",
   include_recent_mails: true,
+  folderSortingRules: [],
 };
 
 export async function getPluginOptions(): Promise<Options> {

--- a/src/retrieveSentContext.ts
+++ b/src/retrieveSentContext.ts
@@ -25,6 +25,7 @@ function findSentFolder(account: MailAccount) {
   return folders.find((folder: MailFolder) => folder.type === "sent");
 }
 
+/** Query sent folder for messages to recipient, returning up to limit most recent messages. */
 async function searchSentFolder(sentFolder: MailFolder, recipientEmail: string, limit = 10) {
   const query: _QueryQueryInfo = {
     recipients: recipientEmail,

--- a/src/thunderbird-alarms.d.ts
+++ b/src/thunderbird-alarms.d.ts
@@ -6,11 +6,13 @@
 declare namespace browser {
   export import _manifest = messenger._manifest;
   export import accounts = messenger.accounts;
+  export import action = messenger.action;
   export import commands = messenger.commands;
   export import compose = messenger.compose;
   export import composeAction = messenger.composeAction;
   export import folders = messenger.folders;
   export import identities = messenger.identities;
+  export import mailTabs = messenger.mailTabs;
   export import menus = messenger.menus;
   export import messages = messenger.messages;
   export import notifications = messenger.notifications;


### PR DESCRIPTION
Move emails from the current folder to a list of folders, according to custom prompts used for the classification.

The moving itself is done algorithmically, preventing too much power being given to an LLM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Organise Folder” settings UI to define folder-sorting rules and refresh folder paths
  * Toolbar action to organise the current folder with loading state and second‑click cancel
  * Batched LLM-assisted classification to move messages according to rules; folder-path listing API added

* **Bug Fixes**
  * Handles cases where the LLM returns no classifications: preserves messages and still notifies on completion

* **Documentation**
  * Added comprehensive project guide with usage, dev notes, and behavioral gotchas

* **Tests**
  * Expanded tests for folder organisation edge cases and LLM response variations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->