### PR TITLE
Generate reports through LLM agentic search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 Quick guide for coding agents in this repo.
 
+## Working efficiently (keep token use low)
+
+- Read only the files you need; prefer targeted `grep`/search over reading whole files. Don't re-read a file already in context.
+- Make focused edits with minimal context; never echo large unchanged regions or full-file dumps back to the user.
+- Don't paste full build/test logs. Run checks, then summarize results in 1-2 lines; show only failing snippets.
+- Keep replies short: a brief plan, the edits, and a concise outcome. Skip restating code you just wrote.
+- Batch independent reads/searches in one step instead of many sequential calls.
+
 ## What this project is
 
 **LLM Composer** is a **Thunderbird MV3 WebExtension** in **TypeScript** that adds LLM help while writing emails.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,4 @@
-# AGENTS.md - tb-llm-composer
-
-Quick guide for coding agents in this repo.
+# tb-llm-composer
 
 ## Working efficiently (keep token use low)
 
@@ -18,9 +16,10 @@ Features:
 - **Compose** from a short prompt (`Ctrl+Alt+L`)
 - **Summarize** the reply thread (`Ctrl+Alt+K`)
 - **Cancel** an in-flight LLM request (`Ctrl+Alt+C`)
-- **Sort a folder** by classifying each message into configured folders (mail-tab action button)
+- **Sort a folder** by classifying each message into configured folders (toolbar action popup)
+- **Generate a report** over the mailbox via agentic LLM tool-calling (toolbar action popup)
 
-It uses any **OpenAI-compatible chat-completions HTTP endpoint**. Endpoint URL, optional bearer token, and model are configured on the options page.
+It uses any **OpenAI-compatible chat-completions HTTP endpoint**. Endpoint URL, optional bearer token, and model are configured on the options page. The endpoint origin is an opt-in **host permission** (not granted at install); the options page requests it via `hostPermissions.ts` on a user gesture, otherwise `fetch` is blocked by CORS.
 
 ## Tech stack
 
@@ -57,9 +56,17 @@ src/
 
   llmButtonClickHandling.ts  compose()/summarize()/cancel() flows; per-tab request state (AllRequestsStatus); think-tag stripping;
                              writes results via browser.compose.setComposeDetails.
-  llmConnection.ts           sendContentToLlm()/callLlmApi(); fetch to LLM endpoint; request/response types; abort + timeout.
+  llmConnection.ts           sendContentToLlm()/callLlmApi(); runAgenticLlm() tool-calling loop; fetch to LLM endpoint;
+                             request/response + tool (LlmToolDefinition/LlmToolHandler) types; abort + timeout.
   promptAndContext.ts        Builds system/user messages (context + prompt) for body, subject, and summary generation.
   emailOrganising.ts         organiseCurrentFolder(); organise folder messages via LLM and move with browser.messages.move() to FolderRule targets.
+                             Also exports resolveFolderPath()/extractTextFromPart() reused by report tools.
+  hostPermissions.ts         Derive/check/request the opt-in host permission for the configured endpoint origin.
+
+  reportGeneration.ts        generateReport(ReportRequest); builds the report system/scope prompt and drives runAgenticLlm.
+  reportTools.ts             search_messages/get_message tool definitions + handlers (ReportScope); assertSearchCapabilities() probe.
+  reports.ts                 Report window UI logic (public/reports.html): create/cancel, iterate on prior report, copy/save txt|md.
+  reports-action.ts          Toolbar action popup (public/reports-action.html): routes to organise-folder toggle or opens report window.
 
   menu.ts                    compose_action menu entries + shortcut labels.
   retrieveSentContext.ts     Gets recent sent mail to a recipient (writing style context).
@@ -72,8 +79,10 @@ src/
   __tests__/                 Vitest specs + setupVitest.ts + testUtils.ts.
 
 manifest.json                MV3 source manifest. Webpack rewrites paths and strips " (dev)" / dev id for production.
-webpack.config.js            Builds background.ts + options.ts into build/; copies icons/, public/, and transformed manifest.json.
+webpack.config.js            Builds background.ts + options.ts + reports.ts + reports-action.ts into build/; copies icons/, public/, and transformed manifest.json.
 public/options.html          Options page markup.
+public/reports.html          Report window markup.
+public/reports-action.html   Toolbar action popup markup.
 icons/                       Extension icons + busy indicator (loader-32px.gif).
 docs/CONTRIBUTING.md         Dev/test/release instructions + sample test emails.
 docs/create_new_release.md   Release process.
@@ -86,7 +95,9 @@ build/                       Generated webpack output (do not edit manually).
 - **Compose flow:** `executeLlmAction` -> `compose()` gathers compose details, recent sent mails, and reply quote; builds prompt/context in `promptAndContext.ts`; optionally generates subject; calls `sendContentToLlm`; writes result back and re-appends signature/quote.
 - **Per-tab request state:** singleton `allRequestsStatus` (`AllRequestsStatus`) holds an `AbortController` by `tabId`; cancel aborts active request; compose-action icon switches to `loader-32px.gif` while running.
 - **LLM HTTP call:** `callLlmApi` POSTs `{ messages, ...params }` to `options.model` (endpoint URL), adds `Authorization: Bearer` if token exists, merges user-abort and timeout signals, and wraps fetch with keep-alive.
-- **Folder sort flow:** mail-tab `browser.action` runs `sortCurrentFolder`; second click cancels through a separate `AbortController` map.
+- **Toolbar action popup:** `browser.action` opens `reports-action.html`; buttons send `organise-folder-toggle` (runs `sortCurrentFolder`) or `open-report-window` (opens the report window) via `browser.runtime.sendMessage`. Background message routing lives in `background.ts` `onMessage`.
+- **Folder sort flow:** `sortCurrentFolder` classifies + moves messages; a repeat toggle cancels through a separate `AbortController` map.
+- **Report flow:** report window (`reports.ts`) sends `generate-report` with a `ReportRequest`; `generateReport` probes search capability (`assertSearchCapabilities`), then `runAgenticLlm` loops the model with `search_messages`/`get_message` tools (token-frugal: metadata first, bodies on demand) up to `reportMaxSteps`. `cancel-report` aborts. Iterating re-sends the prior report as context.
 - **Think-tag handling:** `<think>...</think>` is stripped unless `options.strip_think_tag` is `false`.
 
 ## Conventions and gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md) for the full guide for coding agents in this repo.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A Thunderbird extension enabling LLM support while writing E-Mails.
 
+## Features
+
+- **Compose** an email from a short prompt.
+- **Summarize** the current conversation thread.
+- **Sort a folder** by asking the LLM to classify each message into folders you configure.
+- **Generate a report** over your mailbox: the LLM searches your messages agentically and writes a report you can copy or save as `.txt`/`.md`.
+
+Compose, summarize and cancel are available while writing an email (see [Shortcuts](#shortcuts)).
+Folder sorting and reports are reached from the LLM Composer toolbar button.
+
 ## Requirements
 
 - Thunderbird >= 110.0
@@ -23,6 +33,8 @@ Specify the following things:
   If you don't have access to an LLM, try https://github.com/cheahjs/free-llm-api-resources
 - Api token: Leave empty if public, otherwise obtain one.
 - Optionally: Set a model in "Other options" if the api allows it
+
+When you save the endpoint, Thunderbird asks you to grant access to that host. This permission is required for the plugin to reach the LLM; without it requests are blocked.
 
 ![Thunderbird LLM Plugin Preferences Example](./docs/img/tb-llm-preferences.png)
 

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,8 @@
     "browser_style": false
   },
   "action": {
-    "default_title": "Organise Folder with LLM (dev)",
+    "default_title": "LLM Composer (dev)",
+    "default_popup": "build/public/reports-action.html",
     "default_icon": {
       "16": "icons/icon-16px.png",
       "32": "icons/icon-32px.png",

--- a/public/options.html
+++ b/public/options.html
@@ -251,6 +251,35 @@
         </div>
 
         <div class="settings-section">
+          <h2>Reports</h2>
+          <p style="font-size:13px;color:#555;margin-bottom:8px;">
+            Settings for the agentic "Create Report" feature (action button → Create Report…).
+          </p>
+          <div class="form-group">
+            <label for="report_default_days">Default days in the past:</label>
+            <input type="number" id="report_default_days" name="report default days" min="1" step="1" />
+          </div>
+          <div class="form-group">
+            <label for="report_max_search_results">
+              Max search results per query:
+              <sup title="Upper bound on messages returned by a single search_messages tool call. Lower values reduce token usage.">
+                &#8505;&#65039;
+              </sup>
+            </label>
+            <input type="number" id="report_max_search_results" name="report max search results" min="1" step="1" />
+          </div>
+          <div class="form-group">
+            <label for="report_max_steps">
+              Max agentic steps:
+              <sup title="Upper bound on tool-calling iterations per report. Bounds cost; raise it for more complex reports.">
+                &#8505;&#65039;
+              </sup>
+            </label>
+            <input type="number" id="report_max_steps" name="report max steps" min="1" step="1" />
+          </div>
+        </div>
+
+        <div class="settings-section">
           <h2>Model settings</h2>
           <div class="form-group">
             <label for="context_window">Context window:</label>

--- a/public/options.html
+++ b/public/options.html
@@ -168,6 +168,16 @@
           opacity: 0;
         }
       }
+
+      .url-permission-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 6px;
+      }
+      #url-permission-status {
+        font-size: 13px;
+      }
     </style>
   </head>
   <body>
@@ -178,6 +188,10 @@
           <div class="form-group">
             <label for="url">URL:</label>
             <input type="text" id="url" name="URL" />
+            <div class="url-permission-row">
+              <button type="button" id="grant-access-btn">Grant access</button>
+              <span id="url-permission-status"></span>
+            </div>
           </div>
           <div class="form-group">
             <label for="api_token">Api token:</label>

--- a/public/reports-action.html
+++ b/public/reports-action.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLM Composer</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+        min-width: 220px;
+      }
+      .menu {
+        padding: 4px 0;
+      }
+      .menu-item {
+        appearance: none;
+        display: block;
+        width: 100%;
+        padding: 7px 12px;
+        margin: 0;
+        background: transparent;
+        color: #1f1f1f;
+        border: none;
+        border-radius: 0;
+        cursor: pointer;
+        font-size: 14px;
+        text-align: left;
+      }
+      .menu-item:hover {
+        background: #e9e9ed;
+      }
+      .menu-item:focus-visible {
+        outline: 2px solid #0a84ff;
+        outline-offset: -2px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="menu" role="menu" aria-label="LLM Composer actions">
+      <button type="button" id="organise-btn" class="menu-item" role="menuitem">Organise Folder</button>
+      <button type="button" id="report-btn" class="menu-item" role="menuitem">Create Report...</button>
+    </div>
+    <script src="../reports-action.js"></script>
+  </body>
+</html>
+

--- a/public/reports.html
+++ b/public/reports.html
@@ -5,85 +5,118 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Create Report</title>
     <style>
+      html,
+      body {
+        height: 100%;
+      }
       body {
         font-family: Arial, sans-serif;
         margin: 0;
         padding: 16px;
         color: #222;
+        box-sizing: border-box;
+        /* Column layout so the report field can grow into the space left at the bottom. */
+        display: flex;
+        flex-direction: column;
       }
       h1 {
         font-size: 18px;
         margin: 0 0 12px;
       }
-      .form-group {
-        margin-bottom: 12px;
-      }
-      .form-group label {
-        display: block;
-        margin-bottom: 4px;
+      /* Checkbox and day-count share a single row (Copilot-style compact controls). */
+      .controls-row {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 6px 16px;
         font-size: 13px;
       }
-      input[type="number"],
-      textarea {
-        width: 100%;
+      .control-inline {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        white-space: nowrap;
+      }
+      .controls-row input[type="number"] {
+        width: 56px;
         box-sizing: border-box;
-        padding: 8px;
+        padding: 4px 6px;
         border: 1px solid #ddd;
         border-radius: 4px;
         font-family: inherit;
         font-size: 13px;
       }
-      #prompt {
-        height: 90px;
-        resize: vertical;
-      }
-      .checkbox-row {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 13px;
-      }
       .scope-note {
         font-size: 12px;
         color: #666;
-        margin: 2px 0 0;
+        margin: 4px 0 0;
       }
-      .buttons {
-        display: flex;
-        gap: 8px;
-        margin: 8px 0 12px;
+      /* Prompt field with the send/stop icon docked in its bottom-right corner. */
+      .prompt-box {
+        position: relative;
+        margin: 12px 0 4px;
       }
-      button {
-        padding: 9px 16px;
+      #prompt {
+        width: 100%;
+        box-sizing: border-box;
+        height: 90px;
+        padding: 8px 44px 8px 8px;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        font-family: inherit;
+        font-size: 13px;
+        resize: vertical;
+      }
+      #prompt:focus {
+        outline: none;
+        border-color: #0a84ff;
+      }
+      .icon-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
         border: none;
-        border-radius: 4px;
+        background: transparent;
+        color: #555;
         cursor: pointer;
-        font-size: 14px;
+        border-radius: 6px;
+      }
+      .icon-btn:hover {
+        background: #e9e9ed;
+        color: #1f1f1f;
+      }
+      .icon-btn:focus-visible {
+        outline: 2px solid #0a84ff;
+        outline-offset: 1px;
+      }
+      .icon-btn svg {
+        width: 20px;
+        height: 20px;
+        display: block;
       }
       #create-btn {
-        background-color: #28a745;
-        color: white;
+        position: absolute;
+        right: 8px;
+        bottom: 8px;
+        width: 32px;
+        height: 32px;
+        background: #0a84ff;
+        color: #fff;
       }
       #create-btn:hover {
-        background-color: #1e7e34;
+        background: #0060df;
+        color: #fff;
       }
-      #create-btn:disabled {
-        background-color: #9bd3a9;
-        cursor: default;
+      /* Toggle between the send and stop glyphs depending on generation state. */
+      #create-btn .icon-stop {
+        display: none;
       }
-      #cancel-btn {
-        background-color: #dc3545;
-        color: white;
+      #create-btn.busy .icon-send {
+        display: none;
       }
-      #cancel-btn:hover {
-        background-color: #a71d2a;
-      }
-      #copy-btn {
-        background-color: #007bff;
-        color: white;
-      }
-      #copy-btn:hover {
-        background-color: #0056b3;
+      #create-btn.busy .icon-stop {
+        display: block;
       }
       .output-header {
         display: flex;
@@ -95,10 +128,28 @@
         font-size: 15px;
         margin: 0;
       }
+      .output-actions {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      #copy-btn {
+        width: 28px;
+        height: 28px;
+      }
+      .text-btn {
+        width: auto;
+        height: 28px;
+        padding: 0 8px;
+        font-size: 12px;
+        font-family: inherit;
+      }
       #report-output {
         width: 100%;
         box-sizing: border-box;
-        height: 240px;
+        /* Fill the remaining vertical space at the bottom of the popup. */
+        flex: 1 1 auto;
+        min-height: 120px;
         padding: 8px;
         border: 1px solid #ccc;
         border-radius: 4px;
@@ -107,11 +158,13 @@
         font-size: 13px;
         white-space: pre-wrap;
         overflow-y: auto;
+        resize: none;
       }
       #status {
         font-size: 13px;
         color: #555;
         min-height: 18px;
+        margin: 4px 0 12px;
       }
       .busy {
         display: none;
@@ -127,39 +180,54 @@
   <body>
     <h1>Create Report</h1>
 
-    <div class="checkbox-row">
-      <input type="checkbox" id="folder-only" checked />
-      <label for="folder-only">Search in this folder only</label>
+    <div class="controls-row">
+      <label class="control-inline">
+        <input type="checkbox" id="folder-only" checked />
+        Search in this folder only
+      </label>
+      <span class="control-inline">
+        Last
+        <input type="number" id="days" min="1" step="1" value="30" />
+        days
+      </span>
     </div>
     <p class="scope-note" id="scope-note"></p>
 
-    <div class="form-group" style="margin-top: 12px">
-      <label for="days">How many days in the past to look into emails:</label>
-      <input type="number" id="days" min="1" step="1" value="30" />
-    </div>
-
-    <div class="form-group">
-      <label for="prompt">What report do you want?</label>
+    <div class="prompt-box">
       <textarea
         id="prompt"
         placeholder="e.g. A to-do list of open items addressed to me, or how long Alice took to reply over the last 120 days."
       ></textarea>
-    </div>
-
-    <div class="buttons">
-      <button type="button" id="create-btn">Create</button>
-      <button type="button" id="cancel-btn">Cancel</button>
+      <button type="button" id="create-btn" title="Create report" aria-label="Create report" class="icon-btn">
+        <!-- Paper-plane send glyph shown while idle -->
+        <svg class="icon-send" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M22 2 11 13" />
+          <path d="M22 2 15 22l-4-9-9-4 20-7z" />
+        </svg>
+        <!-- Stop glyph shown while generating -->
+        <svg class="icon-stop" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <rect x="7" y="7" width="10" height="10" rx="2" />
+        </svg>
+      </button>
     </div>
 
     <p id="status"><img class="busy" id="busy" src="../icons/loader-32px.gif" alt="" />Ready.</p>
 
     <div class="output-header">
       <h2>Report</h2>
-      <button type="button" id="copy-btn">Copy</button>
+      <div class="output-actions">
+        <button type="button" id="save-txt-btn" title="Save report as .txt" aria-label="Save report as .txt" class="icon-btn text-btn">.txt</button>
+        <button type="button" id="save-md-btn" title="Save report as .md" aria-label="Save report as .md" class="icon-btn text-btn">.md</button>
+        <button type="button" id="copy-btn" title="Copy report" aria-label="Copy report" class="icon-btn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        </button>
+      </div>
     </div>
     <textarea id="report-output" readonly placeholder="The generated report will appear here."></textarea>
 
     <script src="../reports.js"></script>
   </body>
 </html>
-

--- a/public/reports.html
+++ b/public/reports.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Create Report</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 16px;
+        color: #222;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+      }
+      .form-group {
+        margin-bottom: 12px;
+      }
+      .form-group label {
+        display: block;
+        margin-bottom: 4px;
+        font-size: 13px;
+      }
+      input[type="number"],
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        font-family: inherit;
+        font-size: 13px;
+      }
+      #prompt {
+        height: 90px;
+        resize: vertical;
+      }
+      .checkbox-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 13px;
+      }
+      .scope-note {
+        font-size: 12px;
+        color: #666;
+        margin: 2px 0 0;
+      }
+      .buttons {
+        display: flex;
+        gap: 8px;
+        margin: 8px 0 12px;
+      }
+      button {
+        padding: 9px 16px;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+      }
+      #create-btn {
+        background-color: #28a745;
+        color: white;
+      }
+      #create-btn:hover {
+        background-color: #1e7e34;
+      }
+      #create-btn:disabled {
+        background-color: #9bd3a9;
+        cursor: default;
+      }
+      #cancel-btn {
+        background-color: #dc3545;
+        color: white;
+      }
+      #cancel-btn:hover {
+        background-color: #a71d2a;
+      }
+      #copy-btn {
+        background-color: #007bff;
+        color: white;
+      }
+      #copy-btn:hover {
+        background-color: #0056b3;
+      }
+      .output-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 4px;
+      }
+      .output-header h2 {
+        font-size: 15px;
+        margin: 0;
+      }
+      #report-output {
+        width: 100%;
+        box-sizing: border-box;
+        height: 240px;
+        padding: 8px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #f8f8f8;
+        font-family: inherit;
+        font-size: 13px;
+        white-space: pre-wrap;
+        overflow-y: auto;
+      }
+      #status {
+        font-size: 13px;
+        color: #555;
+        min-height: 18px;
+      }
+      .busy {
+        display: none;
+        vertical-align: middle;
+        height: 16px;
+        margin-right: 6px;
+      }
+      .busy.show {
+        display: inline-block;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Create Report</h1>
+
+    <div class="checkbox-row">
+      <input type="checkbox" id="folder-only" checked />
+      <label for="folder-only">Search in this folder only</label>
+    </div>
+    <p class="scope-note" id="scope-note"></p>
+
+    <div class="form-group" style="margin-top: 12px">
+      <label for="days">How many days in the past to look into emails:</label>
+      <input type="number" id="days" min="1" step="1" value="30" />
+    </div>
+
+    <div class="form-group">
+      <label for="prompt">What report do you want?</label>
+      <textarea
+        id="prompt"
+        placeholder="e.g. A to-do list of open items addressed to me, or how long Alice took to reply over the last 120 days."
+      ></textarea>
+    </div>
+
+    <div class="buttons">
+      <button type="button" id="create-btn">Create</button>
+      <button type="button" id="cancel-btn">Cancel</button>
+    </div>
+
+    <p id="status"><img class="busy" id="busy" src="../icons/loader-32px.gif" alt="" />Ready.</p>
+
+    <div class="output-header">
+      <h2>Report</h2>
+      <button type="button" id="copy-btn">Copy</button>
+    </div>
+    <textarea id="report-output" readonly placeholder="The generated report will appear here."></textarea>
+
+    <script src="../reports.js"></script>
+  </body>
+</html>
+

--- a/public/reports.html
+++ b/public/reports.html
@@ -187,7 +187,7 @@
       </label>
       <span class="control-inline">
         Last
-        <input type="number" id="days" min="1" step="1" value="30" />
+        <input type="number" id="days" min="1" step="1" value="30" aria-label="Number of days in the past to search" />
         days
       </span>
     </div>
@@ -196,6 +196,7 @@
     <div class="prompt-box">
       <textarea
         id="prompt"
+        aria-label="Report request"
         placeholder="e.g. A to-do list of open items addressed to me, or how long Alice took to reply over the last 120 days."
       ></textarea>
       <button type="button" id="create-btn" title="Create report" aria-label="Create report" class="icon-btn">
@@ -214,7 +215,7 @@
     <p id="status"><img class="busy" id="busy" src="../icons/loader-32px.gif" alt="" />Ready.</p>
 
     <div class="output-header">
-      <h2>Report</h2>
+      <h2 id="report-heading">Report</h2>
       <div class="output-actions">
         <button type="button" id="save-txt-btn" title="Save report as .txt" aria-label="Save report as .txt" class="icon-btn text-btn">.txt</button>
         <button type="button" id="save-md-btn" title="Save report as .md" aria-label="Save report as .md" class="icon-btn text-btn">.md</button>
@@ -226,7 +227,7 @@
         </button>
       </div>
     </div>
-    <textarea id="report-output" readonly placeholder="The generated report will appear here."></textarea>
+    <textarea id="report-output" readonly aria-labelledby="report-heading" placeholder="The generated report will appear here."></textarea>
 
     <script src="../reports.js"></script>
   </body>

--- a/src/__tests__/hostPermissions.test.ts
+++ b/src/__tests__/hostPermissions.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { endpointOriginPattern, hasEndpointPermission, requestEndpointPermission } from "../hostPermissions";
+
+const originalBrowser = global.browser;
+
+const containsMock = vi.fn();
+const requestMock = vi.fn();
+
+beforeEach(() => {
+  containsMock.mockReset();
+  requestMock.mockReset();
+  global.browser = {
+    permissions: {
+      contains: containsMock,
+      request: requestMock,
+    },
+  } as unknown as typeof browser;
+});
+
+afterEach(() => {
+  global.browser = originalBrowser;
+});
+
+describe("endpointOriginPattern", () => {
+  test("builds a scheme+host match pattern from a full endpoint URL", () => {
+    expect(endpointOriginPattern("https://chat.model.tngtech.com/v1/chat/completions")).toEqual(
+      "https://chat.model.tngtech.com/*",
+    );
+  });
+
+  test("keeps a non-default port in the pattern", () => {
+    expect(endpointOriginPattern("http://localhost:8080/v1/chat/completions")).toEqual("http://localhost:8080/*");
+  });
+
+  test("returns null for an unparsable URL", () => {
+    expect(endpointOriginPattern("not-a-url")).toBeNull();
+  });
+});
+
+describe("hasEndpointPermission", () => {
+  test("returns true when the origin permission is granted", async () => {
+    containsMock.mockResolvedValue(true);
+
+    await expect(hasEndpointPermission("https://chat.model.tngtech.com/v1")).resolves.toBe(true);
+    expect(containsMock).toHaveBeenCalledWith({ origins: ["https://chat.model.tngtech.com/*"] });
+  });
+
+  test("returns false when the origin permission is not granted", async () => {
+    containsMock.mockResolvedValue(false);
+
+    await expect(hasEndpointPermission("https://chat.model.tngtech.com/v1")).resolves.toBe(false);
+  });
+
+  test("returns false without querying for an unparsable URL", async () => {
+    await expect(hasEndpointPermission("not-a-url")).resolves.toBe(false);
+    expect(containsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestEndpointPermission", () => {
+  test("requests the origin permission and returns the grant result", async () => {
+    requestMock.mockResolvedValue(true);
+
+    await expect(requestEndpointPermission("https://chat.model.tngtech.com/v1")).resolves.toBe(true);
+    expect(requestMock).toHaveBeenCalledWith({ origins: ["https://chat.model.tngtech.com/*"] });
+  });
+
+  test("does not pre-check with contains (request must fire synchronously for the user gesture)", async () => {
+    requestMock.mockResolvedValue(true);
+
+    await requestEndpointPermission("https://chat.model.tngtech.com/v1");
+
+    expect(containsMock).not.toHaveBeenCalled();
+  });
+
+  test("returns false without requesting for an unparsable URL", async () => {
+    await expect(requestEndpointPermission("not-a-url")).resolves.toBe(false);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hostPermissions.test.ts
+++ b/src/__tests__/hostPermissions.test.ts
@@ -28,8 +28,8 @@ describe("endpointOriginPattern", () => {
     );
   });
 
-  test("keeps a non-default port in the pattern", () => {
-    expect(endpointOriginPattern("http://localhost:8080/v1/chat/completions")).toEqual("http://localhost:8080/*");
+  test("drops the port (WebExtension match patterns don't allow ports)", () => {
+    expect(endpointOriginPattern("http://localhost:8080/v1/chat/completions")).toEqual("http://localhost/*");
   });
 
   test("returns null for an unparsable URL", () => {

--- a/src/__tests__/llmConnection.test.ts
+++ b/src/__tests__/llmConnection.test.ts
@@ -1,6 +1,12 @@
-import { afterAll, describe, expect, test } from "vitest";
-import { type LlmApiRequestMessage, LlmRoles, sendContentToLlm } from "../llmConnection";
-import { getMockResponseBody, mockBrowserAndFetch } from "./testUtils";
+import { afterAll, describe, expect, test, vi } from "vitest";
+import {
+  type LlmApiRequestMessage,
+  LlmRoles,
+  type LlmToolDefinition,
+  runAgenticLlm,
+  sendContentToLlm,
+} from "../llmConnection";
+import { getMockResponseBody, mockBrowser, mockBrowserAndFetch } from "./testUtils";
 
 const originalBrowser = global.browser;
 const originalFetch = global.fetch;
@@ -78,5 +84,110 @@ describe("Testing sentContentToLlm", () => {
     await expect(sendContentToLlm([MOCK_CONTEXT, MOCK_PROMPT], abortSignal)).rejects.toThrow(
       `LLM-CONNECTION: Error response from ${MOCK_MODEL_URL}: Error response from LLM API`,
     );
+  });
+});
+
+const TOOLS: LlmToolDefinition[] = [
+  {
+    type: "function",
+    function: { name: "search_messages", description: "search", parameters: { type: "object", properties: {} } },
+  },
+];
+
+function okJson(body: unknown): Partial<Response> {
+  return { ok: true, json: vi.fn().mockResolvedValue(body) };
+}
+
+function toolCallResponse(name: string, args: string) {
+  return {
+    id: "resp-tool",
+    created: 1,
+    model: "m",
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [{ id: "call-1", type: "function", function: { name, arguments: args } }],
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+    finish_reason: "tool_calls",
+  };
+}
+
+function finalResponse(content: string) {
+  return {
+    id: "resp-final",
+    created: 1,
+    model: "m",
+    usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+    choices: [{ index: 0, message: { role: "assistant", content }, finish_reason: "stop" }],
+    finish_reason: "stop",
+  };
+}
+
+describe("runAgenticLlm", () => {
+  afterAll(() => {
+    global.browser = originalBrowser;
+    global.fetch = originalFetch;
+  });
+
+  test("executes tool calls and returns the final answer", async () => {
+    mockBrowser({ options: { model: MOCK_MODEL_URL } });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(okJson(toolCallResponse("search_messages", '{"query":"hi"}')))
+      .mockResolvedValueOnce(okJson(finalResponse("All done")));
+
+    const handler = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const result = await runAgenticLlm(
+      [{ content: "do it", role: LlmRoles.USER }],
+      TOOLS,
+      { search_messages: handler },
+      abortSignal,
+      8,
+    );
+
+    expect(handler).toHaveBeenCalledWith({ query: "hi" });
+    expect(result).toBe("All done");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    // Second request must include the assistant tool-call message and the tool result.
+    const secondBody = JSON.parse(vi.mocked(global.fetch).mock.calls[1][1]?.body as string);
+    const roles = secondBody.messages.map((m: { role: string }) => m.role);
+    expect(roles).toContain("assistant");
+    expect(roles).toContain("tool");
+  });
+
+  test("returns immediately when the model answers without tool calls", async () => {
+    mockBrowser({ options: { model: MOCK_MODEL_URL } });
+    global.fetch = vi.fn().mockResolvedValueOnce(okJson(finalResponse("Quick answer")));
+
+    const result = await runAgenticLlm([{ content: "hi", role: LlmRoles.USER }], TOOLS, {}, abortSignal, 8);
+    expect(result).toBe("Quick answer");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when the endpoint rejects the tool-calling request", async () => {
+    mockBrowser({ options: { model: MOCK_MODEL_URL } });
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, text: async () => "tools unsupported" });
+
+    await expect(runAgenticLlm([{ content: "hi", role: LlmRoles.USER }], TOOLS, {}, abortSignal, 8)).rejects.toThrow(
+      /may not support tool calling/,
+    );
+  });
+
+  test("throws after exceeding maxSteps without a final answer", async () => {
+    mockBrowser({ options: { model: MOCK_MODEL_URL } });
+    global.fetch = vi.fn().mockResolvedValue(okJson(toolCallResponse("search_messages", "{}")));
+
+    const handler = vi.fn().mockResolvedValue([]);
+    await expect(
+      runAgenticLlm([{ content: "hi", role: LlmRoles.USER }], TOOLS, { search_messages: handler }, abortSignal, 2),
+    ).rejects.toThrow(/maximum of 2 steps/);
   });
 });

--- a/src/__tests__/llmConnection.test.ts
+++ b/src/__tests__/llmConnection.test.ts
@@ -19,7 +19,7 @@ const MOCK_PROMPT: LlmApiRequestMessage = {
   content: "Test prompt",
   role: LlmRoles.USER,
 };
-const MOCK_MODEL_URL = "MOCK_MODEL_URL";
+const MOCK_MODEL_URL = "https://mock.llm.test/v1/chat/completions";
 const abortSignal = new AbortController().signal;
 
 describe("Testing sentContentToLlm", () => {
@@ -84,6 +84,16 @@ describe("Testing sentContentToLlm", () => {
     await expect(sendContentToLlm([MOCK_CONTEXT, MOCK_PROMPT], abortSignal)).rejects.toThrow(
       `LLM-CONNECTION: Error response from ${MOCK_MODEL_URL}: Error response from LLM API`,
     );
+  });
+
+  test("throws an actionable error and does not fetch when host permission is missing", async () => {
+    mockBrowserAndFetch({ responseBody: getMockResponseBody(), options: { model: MOCK_MODEL_URL } });
+    vi.mocked(global.browser.permissions.contains).mockResolvedValue(false);
+
+    await expect(sendContentToLlm([MOCK_CONTEXT, MOCK_PROMPT], abortSignal)).rejects.toThrow(
+      `Missing permission to access ${MOCK_MODEL_URL}`,
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/options.test.ts
+++ b/src/__tests__/options.test.ts
@@ -4,7 +4,7 @@
 import fs from "node:fs";
 import * as path from "node:path";
 import { TextDecoder, TextEncoder } from "node:util";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 Object.assign(global, { TextDecoder, TextEncoder });
 
@@ -21,6 +21,9 @@ let optionsDom: JSDOM;
 
 let browserStorage: { [key: string]: object } = {};
 let jsDomNotifications: CreateNotificationOptions[] = [];
+
+const permissionsContainsMock = vi.fn();
+const permissionsRequestMock = vi.fn();
 
 const mockBrowser = {
   storage: {
@@ -42,6 +45,10 @@ const mockBrowser = {
       jsDomNotifications.push(options);
     },
   },
+  permissions: {
+    contains: (...args: unknown[]) => permissionsContainsMock(...args),
+    request: (...args: unknown[]) => permissionsRequestMock(...args),
+  },
 };
 
 /**
@@ -51,6 +58,8 @@ describe("The options page", () => {
   beforeEach(async () => {
     browserStorage = {};
     jsDomNotifications = [];
+    permissionsContainsMock.mockReset().mockResolvedValue(true);
+    permissionsRequestMock.mockReset().mockResolvedValue(true);
     const projectDir = path.resolve(__dirname, "../..");
     const optionsHtmlFile = `${projectDir}/build/public/options.html`;
     const optionsHtmlContent = fs.readFileSync(optionsHtmlFile, "utf-8");
@@ -173,5 +182,46 @@ describe("The options page", () => {
       expect(browserStorage).toHaveProperty("options");
       expect((browserStorage.options as Options).llmContext).toEqual(expectedLlmContext);
     });
+  });
+
+  test("requests host permission for the endpoint when clicking Grant access", async () => {
+    const urlInput = optionsDom.window.document.getElementById("url") as HTMLInputElement;
+    urlInput.value = "https://my-llm.com/v1/chat/completions";
+
+    (optionsDom.window.document.getElementById("grant-access-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(permissionsRequestMock).toHaveBeenCalledWith({ origins: ["https://my-llm.com/*"] });
+      expect(optionsDom.window.document.getElementById("url-permission-status")?.textContent).toContain(
+        "Access granted",
+      );
+    });
+  });
+
+  test("reports when host permission is denied", async () => {
+    permissionsContainsMock.mockResolvedValue(false);
+    permissionsRequestMock.mockResolvedValue(false);
+    const urlInput = optionsDom.window.document.getElementById("url") as HTMLInputElement;
+    urlInput.value = "https://my-llm.com/v1/chat/completions";
+
+    (optionsDom.window.document.getElementById("grant-access-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(jsDomNotifications).toHaveLength(1);
+      expect(jsDomNotifications[0].message).toContain("not granted");
+      expect(optionsDom.window.document.getElementById("url-permission-status")?.textContent).toContain("not granted");
+    });
+  });
+
+  test("does not request permission when the URL is empty", async () => {
+    (optionsDom.window.document.getElementById("url") as HTMLInputElement).value = "";
+
+    (optionsDom.window.document.getElementById("grant-access-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(jsDomNotifications).toHaveLength(1);
+      expect(jsDomNotifications[0].message).toContain("Enter the LLM endpoint URL first");
+    });
+    expect(permissionsRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/reportGeneration.test.ts
+++ b/src/__tests__/reportGeneration.test.ts
@@ -95,9 +95,6 @@ describe("reportGeneration", () => {
 
   test("keeps <think> tags when strip_think_tag is disabled", async () => {
     vi.mocked(getPluginOptions).mockResolvedValue({
-      // biome-ignore lint/suspicious/noExplicitAny: minimal options stub for the test
-    } as any);
-    vi.mocked(getPluginOptions).mockResolvedValue({
       reportMaxSteps: 8,
       reportMaxSearchResults: 50,
       strip_think_tag: false,

--- a/src/__tests__/reportGeneration.test.ts
+++ b/src/__tests__/reportGeneration.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { runAgenticLlmMock, assertSearchCapabilitiesMock, createReportToolHandlersMock } = vi.hoisted(() => ({
+  runAgenticLlmMock: vi.fn(),
+  assertSearchCapabilitiesMock: vi.fn(),
+  createReportToolHandlersMock: vi.fn(),
+}));
+
+vi.mock("../llmConnection", () => ({
+  LlmRoles: { SYSTEM: "system", USER: "user", ASSISTANT: "assistant", TOOL: "tool" },
+  runAgenticLlm: runAgenticLlmMock,
+}));
+
+vi.mock("../reportTools", () => ({
+  assertSearchCapabilities: assertSearchCapabilitiesMock,
+  createReportToolHandlers: createReportToolHandlersMock,
+  reportToolDefinitions: [{ type: "function", function: { name: "search_messages" } }],
+}));
+
+vi.mock("../optionsParams", async () => {
+  const actual = await vi.importActual<typeof import("../optionsParams")>("../optionsParams");
+  return {
+    ...actual,
+    getPluginOptions: vi.fn(async () => ({ ...actual.DEFAULT_OPTIONS })),
+  };
+});
+
+import { getPluginOptions } from "../optionsParams";
+import { generateReport, type ReportRequest } from "../reportGeneration";
+
+const abortSignal = new AbortController().signal;
+
+const BASE_REQUEST: ReportRequest = {
+  prompt: "Make me a todo list",
+  days: 14,
+  folderOnly: true,
+  folder: { accountId: "a", path: "/INBOX" },
+};
+
+describe("reportGeneration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-05T12:00:00Z"));
+    runAgenticLlmMock.mockReset().mockResolvedValue("Final report");
+    assertSearchCapabilitiesMock.mockReset().mockResolvedValue(undefined);
+    createReportToolHandlersMock.mockReset().mockReturnValue({ search_messages: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(getPluginOptions).mockReset?.();
+  });
+
+  test("validates search capabilities before running the loop", async () => {
+    await generateReport(BASE_REQUEST, abortSignal);
+    expect(assertSearchCapabilitiesMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws (and does not run the loop) if search capabilities are missing", async () => {
+    assertSearchCapabilitiesMock.mockRejectedValue(new Error("Email search is not available"));
+    await expect(generateReport(BASE_REQUEST, abortSignal)).rejects.toThrow(/Email search is not available/);
+    expect(runAgenticLlmMock).not.toHaveBeenCalled();
+  });
+
+  test("passes tools, handlers, abort signal and maxSteps to the agentic loop", async () => {
+    await generateReport(BASE_REQUEST, abortSignal);
+
+    expect(runAgenticLlmMock).toHaveBeenCalledTimes(1);
+    const [messages, tools, handlers, signal, maxSteps] = runAgenticLlmMock.mock.calls[0];
+    expect(tools).toEqual([{ type: "function", function: { name: "search_messages" } }]);
+    expect(handlers).toEqual({ search_messages: expect.any(Function) });
+    expect(signal).toBe(abortSignal);
+    expect(maxSteps).toBe(8); // DEFAULT_OPTIONS.reportMaxSteps
+    expect(messages[0].role).toBe("system");
+    expect(messages.some((m: { content: string }) => m.content.includes("Make me a todo list"))).toBe(true);
+    expect(
+      messages.some((m: { content: string }) =>
+        m.content.includes("Default date range (computed now): 2026-05-22 to 2026-06-05."),
+      ),
+    ).toBe(true);
+    expect(messages.some((m: { content: string }) => m.content.includes("Report run date: 2026-06-05."))).toBe(true);
+  });
+
+  test("includes the prior report when refining", async () => {
+    await generateReport({ ...BASE_REQUEST, priorReport: "PREVIOUS REPORT" }, abortSignal);
+    const [messages] = runAgenticLlmMock.mock.calls[0];
+    expect(messages.some((m: { content: string }) => m.content.includes("PREVIOUS REPORT"))).toBe(true);
+  });
+
+  test("strips <think> tags from the report by default", async () => {
+    runAgenticLlmMock.mockResolvedValue("<think>reasoning</think>Clean report");
+    const result = await generateReport(BASE_REQUEST, abortSignal);
+    expect(result).toBe("Clean report");
+  });
+
+  test("keeps <think> tags when strip_think_tag is disabled", async () => {
+    vi.mocked(getPluginOptions).mockResolvedValue({
+      // biome-ignore lint/suspicious/noExplicitAny: minimal options stub for the test
+    } as any);
+    vi.mocked(getPluginOptions).mockResolvedValue({
+      reportMaxSteps: 8,
+      reportMaxSearchResults: 50,
+      strip_think_tag: false,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal options stub for the test
+    } as any);
+    runAgenticLlmMock.mockResolvedValue("<think>keep</think>Report");
+
+    const result = await generateReport(BASE_REQUEST, abortSignal);
+    expect(result).toContain("<think>keep</think>");
+  });
+});

--- a/src/__tests__/reportTools.test.ts
+++ b/src/__tests__/reportTools.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { resolveFolderPathMock, extractTextFromPartMock } = vi.hoisted(() => ({
+  resolveFolderPathMock: vi.fn(),
+  extractTextFromPartMock: vi.fn(),
+}));
+
+vi.mock("../emailOrganising", () => ({
+  resolveFolderPath: resolveFolderPathMock,
+  extractTextFromPart: extractTextFromPartMock,
+}));
+
+import {
+  assertSearchCapabilities,
+  createReportToolHandlers,
+  type ReportScope,
+  reportToolDefinitions,
+} from "../reportTools";
+
+const originalBrowser = global.browser;
+
+const BASE_SCOPE: ReportScope = {
+  folderOnly: false,
+  folder: null,
+  defaultDays: 30,
+  maxSearchResults: 50,
+};
+
+function setBrowser(overrides: Record<string, unknown>): void {
+  global.browser = {
+    messages: {
+      query: vi.fn().mockResolvedValue({ messages: [] }),
+      continueList: vi.fn(),
+      get: vi.fn(),
+      getFull: vi.fn(),
+      ...overrides,
+    },
+  } as unknown as typeof browser;
+}
+
+describe("reportTools", () => {
+  beforeEach(() => {
+    resolveFolderPathMock.mockReset();
+    extractTextFromPartMock.mockReset();
+  });
+
+  afterEach(() => {
+    global.browser = originalBrowser;
+  });
+
+  test("exposes search_messages and get_message tool definitions", () => {
+    const names = reportToolDefinitions.map((t) => t.function.name);
+    expect(names).toEqual(["search_messages", "get_message"]);
+  });
+
+  describe("assertSearchCapabilities", () => {
+    test("passes a fromDate/author/fullText probe to messages.query", async () => {
+      const query = vi.fn().mockResolvedValue({ messages: [] });
+      setBrowser({ query });
+
+      await assertSearchCapabilities(BASE_SCOPE);
+
+      expect(query).toHaveBeenCalledTimes(1);
+      const probe = query.mock.calls[0][0];
+      expect(probe.fromDate).toBeInstanceOf(Date);
+      expect(probe.author).toBeTruthy();
+      expect(probe.fullText).toBeTruthy();
+    });
+
+    test("throws a clear error when querying is not supported", async () => {
+      const query = vi.fn().mockRejectedValue(new Error("not implemented"));
+      setBrowser({ query });
+
+      await expect(assertSearchCapabilities(BASE_SCOPE)).rejects.toThrow(/Email search is not available/);
+    });
+  });
+
+  describe("search_messages", () => {
+    test("maps query args to messages.query and returns compact metadata only", async () => {
+      const query = vi.fn().mockResolvedValue({
+        id: undefined,
+        messages: [
+          {
+            id: 1,
+            date: new Date("2026-01-01T00:00:00Z"),
+            author: "alice@example.com",
+            recipients: ["me@example.com"],
+            subject: "Hello",
+          },
+        ],
+      });
+      setBrowser({ query });
+
+      const handlers = createReportToolHandlers(BASE_SCOPE);
+      const result = (await handlers.search_messages({ query: "invoice", author: "alice" })) as Array<
+        Record<string, unknown>
+      >;
+
+      expect(query).toHaveBeenCalledTimes(1);
+      const queryInfo = query.mock.calls[0][0];
+      expect(queryInfo.fullText).toBe("invoice");
+      expect(queryInfo.author).toBe("alice");
+      expect(queryInfo.fromDate).toBeInstanceOf(Date);
+      expect(result).toEqual([
+        {
+          id: 1,
+          date: "2026-01-01T00:00:00.000Z",
+          author: "alice@example.com",
+          recipients: ["me@example.com"],
+          subject: "Hello",
+        },
+      ]);
+      // No body field is leaked in search results.
+      expect(result[0]).not.toHaveProperty("body");
+    });
+
+    test("respects maxSearchResults cap across paged results", async () => {
+      const page1 = {
+        id: "page-1",
+        messages: [
+          { id: 1, subject: "a", author: "x", recipients: [] },
+          { id: 2, subject: "b", author: "x", recipients: [] },
+        ],
+      };
+      const page2 = {
+        id: undefined,
+        messages: [{ id: 3, subject: "c", author: "x", recipients: [] }],
+      };
+      const query = vi.fn().mockResolvedValue(page1);
+      const continueList = vi.fn().mockResolvedValue(page2);
+      setBrowser({ query, continueList });
+
+      const handlers = createReportToolHandlers({ ...BASE_SCOPE, maxSearchResults: 2 });
+      const result = (await handlers.search_messages({})) as unknown[];
+
+      expect(result).toHaveLength(2);
+      // Cap reached on first page, so continueList is never called.
+      expect(continueList).not.toHaveBeenCalled();
+    });
+
+    test("filters subjects as a case-insensitive substring instead of an exact query match", async () => {
+      const query = vi.fn().mockResolvedValue({
+        id: undefined,
+        messages: [
+          { id: 1, subject: "Einladung zur Schulung am Montag", author: "x", recipients: [] },
+          { id: 2, subject: "Rechnung Februar", author: "x", recipients: [] },
+          { id: 3, subject: "SCHULUNG abgesagt", author: "x", recipients: [] },
+        ],
+      });
+      setBrowser({ query });
+
+      const handlers = createReportToolHandlers(BASE_SCOPE);
+      const result = (await handlers.search_messages({ subject: "schulung" })) as Array<Record<string, unknown>>;
+
+      // `subject` must not be forwarded as an exact-match query field.
+      expect(query.mock.calls[0][0]).not.toHaveProperty("subject");
+      expect(result.map((r) => r.id)).toEqual([1, 3]);
+    });
+
+    test("restricts to the active folder id when folderOnly is set", async () => {
+      const query = vi.fn().mockResolvedValue({ messages: [] });
+      setBrowser({ query });
+      resolveFolderPathMock.mockResolvedValue({ id: "folder-7", accountId: "a", path: "/INBOX", name: "Inbox" });
+
+      const handlers = createReportToolHandlers({
+        ...BASE_SCOPE,
+        folderOnly: true,
+        folder: { accountId: "a", path: "/INBOX" },
+      });
+      await handlers.search_messages({});
+
+      expect(resolveFolderPathMock).toHaveBeenCalledWith("/INBOX");
+      expect(query.mock.calls[0][0].folderId).toBe("folder-7");
+    });
+  });
+
+  describe("get_message", () => {
+    test("returns a truncated plain-text body", async () => {
+      const longBody = "x".repeat(5000);
+      extractTextFromPartMock.mockReturnValue(longBody);
+      const get = vi.fn().mockResolvedValue({
+        date: new Date("2026-02-02T00:00:00Z"),
+        author: "bob@example.com",
+        subject: "Re: Hi",
+      });
+      const getFull = vi.fn().mockResolvedValue({ contentType: "text/plain", body: longBody });
+      setBrowser({ get, getFull });
+
+      const handlers = createReportToolHandlers(BASE_SCOPE);
+      const result = (await handlers.get_message({ id: 42 })) as { id: number; body: string; author: string };
+
+      expect(get).toHaveBeenCalledWith(42);
+      expect(getFull).toHaveBeenCalledWith(42);
+      expect(result.id).toBe(42);
+      expect(result.author).toBe("bob@example.com");
+      expect(result.body.length).toBe(1200);
+    });
+
+    test("throws when id is not numeric", async () => {
+      setBrowser({});
+      const handlers = createReportToolHandlers(BASE_SCOPE);
+      await expect(handlers.get_message({ id: "not-a-number" })).rejects.toThrow(/numeric 'id'/);
+    });
+
+    test("returns a recoverable hint when the message id does not exist", async () => {
+      const get = vi.fn().mockRejectedValue(new Error("Message not found: 51291."));
+      const getFull = vi.fn();
+      setBrowser({ get, getFull });
+
+      const handlers = createReportToolHandlers(BASE_SCOPE);
+      await expect(handlers.get_message({ id: 51291 })).rejects.toThrow(/No message exists with id 51291/);
+      expect(getFull).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/reports.test.ts
+++ b/src/__tests__/reports.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @vi-environment jsdom
+ *
+ * Runs against the compiled report popup (build/public/reports.html + build/reports.js).
+ */
+import fs from "node:fs";
+import * as path from "node:path";
+import { TextDecoder, TextEncoder } from "node:util";
+import { JSDOM } from "jsdom";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { waitFor } from "./testUtils";
+
+Object.assign(global, { TextDecoder, TextEncoder });
+
+let reportsDom: JSDOM;
+
+const getCurrentMock = vi.fn();
+const sendMessageMock = vi.fn();
+const clipboardWriteMock = vi.fn();
+const createObjectUrlMock = vi.fn();
+const revokeObjectUrlMock = vi.fn();
+
+/** Captures the anchors that would have triggered a file download. */
+let triggeredDownloads: Array<{ download: string; href: string }>;
+
+const mockBrowser = {
+  windows: {
+    getCurrent: (...args: unknown[]) => getCurrentMock(...args),
+  },
+  runtime: {
+    sendMessage: (...args: unknown[]) => sendMessageMock(...args),
+  },
+  storage: {
+    sync: {
+      get: async () => ({}),
+    },
+  },
+};
+
+async function loadPopup(search: string): Promise<void> {
+  const projectDir = path.resolve(__dirname, "../..");
+  const reportsHtmlFile = `${projectDir}/build/public/reports.html`;
+  const reportsHtmlContent = fs.readFileSync(reportsHtmlFile, "utf-8");
+  reportsDom = new JSDOM(reportsHtmlContent, {
+    url: `file://${reportsHtmlFile}${search}`,
+    runScripts: "dangerously",
+    resources: "usable",
+  });
+
+  const win = reportsDom.window;
+  win.URL.createObjectURL = createObjectUrlMock as unknown as typeof URL.createObjectURL;
+  win.URL.revokeObjectURL = revokeObjectUrlMock as unknown as typeof URL.revokeObjectURL;
+  win.HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+    triggeredDownloads.push({ download: this.download, href: this.href });
+  };
+  Object.defineProperty(win.navigator, "clipboard", {
+    value: { writeText: clipboardWriteMock },
+    configurable: true,
+  });
+
+  reportsDom.getInternalVMContext().browser = mockBrowser;
+
+  // Let the async external script load and init() run.
+  await new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+const FOLDER_SEARCH = "?accountId=acc1&path=/INBOX&name=Inbox";
+
+beforeEach(() => {
+  triggeredDownloads = [];
+  getCurrentMock.mockReset().mockResolvedValue({ id: 123 });
+  sendMessageMock.mockReset().mockResolvedValue({});
+  clipboardWriteMock.mockReset().mockResolvedValue(undefined);
+  createObjectUrlMock.mockReset().mockReturnValue("blob:mock-url");
+  revokeObjectUrlMock.mockReset();
+});
+
+afterEach(() => {
+  reportsDom.window.close();
+});
+
+describe("The report popup", () => {
+  test("prefills the scope note from the folder context in the URL", async () => {
+    await loadPopup(FOLDER_SEARCH);
+
+    const scopeNote = reportsDom.window.document.getElementById("scope-note");
+    expect(scopeNote?.textContent).toContain("Inbox");
+  });
+
+  test("searches all folders when no folder context is provided", async () => {
+    await loadPopup("");
+
+    const folderOnly = reportsDom.window.document.getElementById("folder-only") as HTMLInputElement;
+    expect(folderOnly.checked).toBe(false);
+    expect(folderOnly.disabled).toBe(true);
+    expect(reportsDom.window.document.getElementById("scope-note")?.textContent).toContain("all folders");
+  });
+
+  test("requests a report and renders it in the output area", async () => {
+    sendMessageMock.mockResolvedValue({ report: "GENERATED REPORT BODY" });
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("prompt") as HTMLTextAreaElement).value = "Give me a to-do list";
+    (doc.getElementById("create-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect((doc.getElementById("report-output") as HTMLTextAreaElement).value).toEqual("GENERATED REPORT BODY");
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "generate-report",
+        windowId: 123,
+        request: expect.objectContaining({
+          prompt: "Give me a to-do list",
+          folderOnly: true,
+          folder: { accountId: "acc1", path: "/INBOX" },
+        }),
+      }),
+    );
+  });
+
+  test("does not send a request when the prompt is empty", async () => {
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("create-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(doc.getElementById("status")?.textContent).toContain("Please enter a report request");
+    });
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("shows an error status when generation fails", async () => {
+    sendMessageMock.mockResolvedValue({ error: "endpoint exploded" });
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("prompt") as HTMLTextAreaElement).value = "anything";
+    (doc.getElementById("create-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(doc.getElementById("status")?.textContent).toContain("endpoint exploded");
+    });
+  });
+
+  test("saves the report as .txt with the default filename", async () => {
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("report-output") as HTMLTextAreaElement).value = "report contents";
+    (doc.getElementById("save-txt-btn") as HTMLButtonElement).click();
+
+    expect(createObjectUrlMock).toHaveBeenCalledTimes(1);
+    expect(triggeredDownloads).toEqual([{ download: "llm-composer-report.txt", href: "blob:mock-url" }]);
+  });
+
+  test("saves the report as .md with the default filename", async () => {
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("report-output") as HTMLTextAreaElement).value = "# report";
+    (doc.getElementById("save-md-btn") as HTMLButtonElement).click();
+
+    expect(triggeredDownloads).toEqual([{ download: "llm-composer-report.md", href: "blob:mock-url" }]);
+  });
+
+  test("does not trigger a download when there is nothing to save", async () => {
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("save-txt-btn") as HTMLButtonElement).click();
+
+    expect(createObjectUrlMock).not.toHaveBeenCalled();
+    expect(triggeredDownloads).toHaveLength(0);
+    expect(doc.getElementById("status")?.textContent).toContain("Nothing to save");
+  });
+
+  test("copies the report to the clipboard", async () => {
+    await loadPopup(FOLDER_SEARCH);
+
+    const doc = reportsDom.window.document;
+    (doc.getElementById("report-output") as HTMLTextAreaElement).value = "copy me";
+    (doc.getElementById("copy-btn") as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(clipboardWriteMock).toHaveBeenCalledWith("copy me");
+      expect(doc.getElementById("status")?.textContent).toContain("copied");
+    });
+  });
+});

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -115,6 +115,10 @@ export function mockBrowser(args: mockBrowserArgs) {
     notifications: {
       create: vi.fn(),
     },
+    permissions: {
+      contains: vi.fn().mockResolvedValue(true),
+      request: vi.fn().mockResolvedValue(true),
+    },
     menus: {
       removeAll: async () => {
         mockBrowserMenus = [];

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,9 +1,10 @@
-import { getAllFolderPaths, organiseCurrentFolder } from "./emailOrganising";
+import { getActiveMailFolder, getAllFolderPaths, organiseCurrentFolder } from "./emailOrganising";
 import { handleKeepAliveAlarm } from "./keepAlive";
 import { executeLlmAction, type LlmPluginAction } from "./llmButtonClickHandling";
 import { addLlmActionsToMenu, enableSummarizeMenuEntryIfReply, handleMenuClickListener } from "./menu";
 import { notifyOnError, timedNotification } from "./notifications";
 import { deleteFromOriginalTabCache, storeOriginalReplyText } from "./originalTabConversation";
+import { generateReport, type ReportRequest } from "./reportGeneration";
 
 import Tab = browser.tabs.Tab;
 
@@ -24,29 +25,18 @@ browser.tabs.onCreated.addListener(async (tab: Tab) => {
 browser.tabs.onRemoved.addListener(deleteFromOriginalTabCache);
 browser.menus.onClicked.addListener(handleMenuClickListener);
 
-// ── Organise-folder action (shown in mail tabs) ───────────────────────────────
-// Thunderbird MV3 uses browser.action; guard in case the API is not available.
-const organiseAbortControllers = new Map<number, AbortController>();
+// ── Organise-folder action (popup shown in mail tabs) ─────────────────────────
+// Only one organise run happens at a time; a second trigger cancels it.
+let organiseAbortController: AbortController | null = null;
 
-/** Get clicked tab ID, falling back to active tab if none provided. */
-async function resolveClickedTabId(tab?: Tab): Promise<number | undefined> {
-  if (tab?.id !== undefined) {
-    return tab.id;
-  }
-
-  // Thunderbird may invoke action clicks without a tab payload in some contexts.
-  const activeTabs = await browser.tabs.query({ active: true, currentWindow: true });
-  return activeTabs[0]?.id;
-}
-
-/** Update compose action icon and title to reflect loading/idle state. */
+/** Update the action icon/title to reflect organise loading/idle state. */
 async function setOrganiseActionState(loading: boolean) {
   try {
     if (loading) {
-      await browser.action.setTitle({ title: "Cancel Organise Folder (click to stop)" });
+      await browser.action.setTitle({ title: "LLM Composer — organising… (open menu to cancel)" });
       await browser.action.setIcon({ path: { 32: "icons/loader-32px.gif" } });
     } else {
-      await browser.action.setTitle({ title: "Organise Folder with LLM (dev)" });
+      await browser.action.setTitle({ title: "LLM Composer (dev)" });
       await browser.action.setIcon({
         path: { 16: "icons/icon-16px.png", 32: "icons/icon-32px.png", 64: "icons/icon-64px.png" },
       });
@@ -56,47 +46,82 @@ async function setOrganiseActionState(loading: boolean) {
   }
 }
 
-if (browser.action?.onClicked) {
-  console.log("ORGANISE: Registering browser.action.onClicked listener");
-  browser.action.onClicked.addListener(async (tab?: Tab) => {
-    console.log("ORGANISE: Action button clicked, tab:", tab?.id);
-    const tabId = await resolveClickedTabId(tab);
-    if (tabId === undefined) {
-      console.error("ORGANISE: No tabId on click");
-      await timedNotification(
-        "LLM Composer",
-        "Could not detect the active tab for organise folder. Please click the button in a mail tab.",
-        7000,
-      );
-      return;
-    }
+/** Start organising the active folder, or cancel an in-flight run if one exists. */
+async function toggleOrganiseFolder(): Promise<void> {
+  if (organiseAbortController) {
+    console.log("ORGANISE: Aborting existing organise-folder run");
+    organiseAbortController.abort(new DOMException("User cancelled organise folder", "AbortError"));
+    organiseAbortController = null;
+    await setOrganiseActionState(false);
+    return;
+  }
 
-    // Second click = cancel
-    if (organiseAbortControllers.has(tabId)) {
-      console.log("ORGANISE: Aborting existing organise-folder run for tab", tabId);
-      organiseAbortControllers.get(tabId)?.abort(new DOMException("User cancelled organise folder", "AbortError"));
-      organiseAbortControllers.delete(tabId);
-      await setOrganiseActionState(false);
-      return;
-    }
+  const abortController = new AbortController();
+  organiseAbortController = abortController;
+  await setOrganiseActionState(true);
 
-    const abortController = new AbortController();
-    organiseAbortControllers.set(tabId, abortController);
-    await setOrganiseActionState(true);
-
-    await notifyOnError(async () => {
-      try {
-        await organiseCurrentFolder(abortController.signal);
-      } finally {
-        organiseAbortControllers.delete(tabId);
-        await setOrganiseActionState(false);
+  await notifyOnError(async () => {
+    try {
+      await organiseCurrentFolder(abortController.signal);
+    } finally {
+      if (organiseAbortController === abortController) {
+        organiseAbortController = null;
       }
-    });
+      await setOrganiseActionState(false);
+    }
   });
-} else {
-  console.error("ORGANISE: browser.action.onClicked is not available in this Thunderbird version.");
-  timedNotification("LLM Composer", "Organise folder button requires Thunderbird 128 or later.", 10000);
 }
+
+// ── Create-report flow ────────────────────────────────────────────────────────
+// One AbortController per report window, keyed by the window id.
+const reportAbortControllers = new Map<number, AbortController>();
+
+/** Open the report window, seeding it with the active folder context via URL params. */
+async function openReportWindow(): Promise<void> {
+  const folder = await getActiveMailFolder();
+  const params = new URLSearchParams();
+  if (folder?.accountId) params.set("accountId", folder.accountId);
+  if (folder?.path) params.set("path", folder.path);
+  if (folder?.name) params.set("name", folder.name);
+
+  await browser.windows.create({
+    type: "popup",
+    url: `build/public/reports.html?${params.toString()}`,
+    width: 640,
+    height: 720,
+  });
+}
+
+async function runReport(windowId: number, request: ReportRequest): Promise<{ report?: string; error?: string }> {
+  // Cancel any previous run for this window before starting a new one.
+  reportAbortControllers.get(windowId)?.abort(new DOMException("Superseded by a new report", "AbortError"));
+
+  const abortController = new AbortController();
+  reportAbortControllers.set(windowId, abortController);
+  try {
+    const report = await generateReport(request, abortController.signal);
+    return { report };
+  } catch (e) {
+    if ((e as Error).name === "AbortError") {
+      return { error: "Report generation was cancelled." };
+    }
+    console.error("REPORT: generation failed:", e);
+    return { error: (e as Error).message };
+  } finally {
+    if (reportAbortControllers.get(windowId) === abortController) {
+      reportAbortControllers.delete(windowId);
+    }
+  }
+}
+
+// Clean up an in-flight report when its window is closed.
+browser.windows.onRemoved.addListener((windowId: number) => {
+  const controller = reportAbortControllers.get(windowId);
+  if (controller) {
+    controller.abort(new DOMException("Report window closed", "AbortError"));
+    reportAbortControllers.delete(windowId);
+  }
+});
 
 // Register menu entries without blocking listener registration; this keeps
 // click handlers responsive when MV3 wakes the background script on demand.
@@ -104,19 +129,67 @@ void addLlmActionsToMenu().catch((e) => {
   console.error("BACKGROUND: Failed to add LLM actions to menu:", e);
 });
 
-type RuntimeRequestMessage = {
-  type: "get-folder-paths";
-};
+if (!browser.action) {
+  console.error("ORGANISE: browser.action is not available in this Thunderbird version.");
+  timedNotification("LLM Composer", "The action button requires Thunderbird 128 or later.", 10000);
+}
+
+// ── Runtime messages (options page + action popup + report window) ─────────────
+type ReportFolderPayload = { accountId: string; path: string } | null;
+
+type RuntimeRequestMessage =
+  | { type: "get-folder-paths" }
+  | { type: "organise-folder-toggle" }
+  | { type: "open-report-window" }
+  | { type: "get-active-folder" }
+  | { type: "generate-report"; windowId: number; request: ReportRequest }
+  | { type: "cancel-report"; windowId: number };
 
 function isRuntimeRequestMessage(value: unknown): value is RuntimeRequestMessage {
   if (!value || typeof value !== "object") return false;
-  return (value as { type?: unknown }).type === "get-folder-paths";
+  const type = (value as { type?: unknown }).type;
+  return (
+    type === "get-folder-paths" ||
+    type === "organise-folder-toggle" ||
+    type === "open-report-window" ||
+    type === "get-active-folder" ||
+    type === "generate-report" ||
+    type === "cancel-report"
+  );
 }
 
-// Handle options-page requests that need background-context APIs.
+// Handle requests that need background-context APIs.
 browser.runtime.onMessage.addListener((message: unknown) => {
   if (!isRuntimeRequestMessage(message)) {
     return false;
   }
-  return getAllFolderPaths();
+
+  switch (message.type) {
+    case "get-folder-paths":
+      return getAllFolderPaths();
+
+    case "organise-folder-toggle":
+      return toggleOrganiseFolder().then(() => ({ ok: true }));
+
+    case "open-report-window":
+      return openReportWindow().then(() => ({ ok: true }));
+
+    case "get-active-folder":
+      return getActiveMailFolder().then((folder): { folder: ReportFolderPayload } => ({
+        folder: folder?.accountId && folder?.path ? { accountId: folder.accountId, path: folder.path } : null,
+      }));
+
+    case "generate-report":
+      return runReport(message.windowId, message.request);
+
+    case "cancel-report": {
+      const controller = reportAbortControllers.get(message.windowId);
+      controller?.abort(new DOMException("User cancelled report", "AbortError"));
+      reportAbortControllers.delete(message.windowId);
+      return Promise.resolve({ ok: true });
+    }
+
+    default:
+      return false;
+  }
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -84,9 +84,15 @@ async function openReportWindow(): Promise<void> {
   if (folder?.path) params.set("path", folder.path);
   if (folder?.name) params.set("name", folder.name);
 
+  // reports.html sits next to the options page in public/. Resolve it relative to the options
+  // page URL so the path is correct whether the extension root is the repo (paths prefixed with
+  // build/) or the packaged build/ folder (prefix stripped by the manifest transform).
+  const optionsPage = browser.runtime.getManifest().options_ui?.page ?? "public/options.html";
+  const reportsUrl = new URL(`reports.html?${params.toString()}`, browser.runtime.getURL(optionsPage)).href;
+
   await browser.windows.create({
     type: "popup",
-    url: `build/public/reports.html?${params.toString()}`,
+    url: reportsUrl,
     width: 640,
     height: 720,
   });

--- a/src/emailOrganising.ts
+++ b/src/emailOrganising.ts
@@ -152,7 +152,7 @@ async function getFoldersForAccount(account: browser.accounts.MailAccount): Prom
 }
 
 /** Resolve a folderPath string like "/INBOX/Work" to a MailFolder object. */
-async function resolveFolderPath(folderPath: string): Promise<browser.folders.MailFolder | null> {
+export async function resolveFolderPath(folderPath: string): Promise<browser.folders.MailFolder | null> {
   const accounts = await browser.accounts.list(true);
   for (const account of accounts) {
     const foundInRoot = account.rootFolder?.path === folderPath ? account.rootFolder : null;
@@ -194,6 +194,21 @@ function collectPaths(folders: browser.folders.MailFolder[], out: Set<string>) {
     out.add(f.path);
     collectPaths(f.subFolders ?? [], out);
   }
+}
+
+/**
+ * Return the active mail tab's displayed folder across normal mail windows. Unlike a
+ * `currentWindow` query this ignores extension popup windows, so it keeps working when the
+ * caller was triggered from the action popup or a report window.
+ */
+export async function getActiveMailFolder(): Promise<browser.folders.MailFolder | undefined> {
+  const mailTabs = await browser.mailTabs.query({ active: true });
+  for (const mailTab of mailTabs) {
+    if (mailTab.displayedFolder) {
+      return mailTab.displayedFolder;
+    }
+  }
+  return undefined;
 }
 
 function isIncorrectMessagesListArgumentError(error: unknown): boolean {
@@ -288,13 +303,11 @@ export async function organiseCurrentFolder(abortSignal: AbortSignal): Promise<v
   }
 
   // Get active mail tab and its current folder.
-  const mailTabs = await browser.mailTabs.query({ active: true, currentWindow: true });
-  const mailTab = mailTabs[0];
-  if (!mailTab?.displayedFolder) {
+  const sourceFolder = await getActiveMailFolder();
+  if (!sourceFolder) {
     throw new Error("No folder is currently displayed. Open a mail folder first.");
   }
 
-  const sourceFolder = mailTab.displayedFolder;
   console.log("ORGANISE: displayedFolder raw:", JSON.stringify(sourceFolder));
 
   // Collect all messages (the API pages results).
@@ -429,7 +442,7 @@ export async function organiseCurrentFolder(abortSignal: AbortSignal): Promise<v
 }
 
 /** Recursively extract text (plain or stripped HTML) from message part hierarchy. */
-function extractTextFromPart(part: browser.messages.MessagePart): string {
+export function extractTextFromPart(part: browser.messages.MessagePart): string {
   if (part.contentType === "text/plain" && part.body) {
     return part.body;
   }

--- a/src/hostPermissions.ts
+++ b/src/hostPermissions.ts
@@ -1,0 +1,37 @@
+/**
+ * Host-permission helpers for the configured LLM endpoint.
+ *
+ * In a Thunderbird/Firefox MV3 extension, entries in `host_permissions` are opt-in: they are
+ * NOT granted at install time. Until the user grants the origin, even background-context
+ * `fetch`es to it are subject to CORS and get blocked ("Access-Control-Allow-Origin missing").
+ * These helpers derive the endpoint origin and let us check/request that permission.
+ */
+
+/** Build an origin match pattern (`scheme://host/*`) for the endpoint URL, or null if unparsable. */
+export function endpointOriginPattern(endpointUrl: string): string | null {
+  try {
+    const url = new URL(endpointUrl);
+    return `${url.protocol}//${url.host}/*`;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the host permission for the endpoint's origin is currently granted. */
+export async function hasEndpointPermission(endpointUrl: string): Promise<boolean> {
+  const origin = endpointOriginPattern(endpointUrl);
+  if (!origin) return false;
+  return browser.permissions.contains({ origins: [origin] });
+}
+
+/**
+ * Request the host permission for the endpoint's origin (idempotent: resolves true without a
+ * prompt if already granted). `browser.permissions.request` requires an active user gesture and
+ * Firefox drops that flag across `await`, so this issues the request synchronously (no pre-check)
+ * and must be called before any other await in a user-input handler (e.g. the options page).
+ */
+export function requestEndpointPermission(endpointUrl: string): Promise<boolean> {
+  const origin = endpointOriginPattern(endpointUrl);
+  if (!origin) return Promise.resolve(false);
+  return browser.permissions.request({ origins: [origin] });
+}

--- a/src/hostPermissions.ts
+++ b/src/hostPermissions.ts
@@ -11,7 +11,8 @@
 export function endpointOriginPattern(endpointUrl: string): string | null {
   try {
     const url = new URL(endpointUrl);
-    return `${url.protocol}//${url.host}/*`;
+    // Use hostname (never host): WebExtension match patterns don't allow ports.
+    return `${url.protocol}//${url.hostname}/*`;
   } catch {
     return null;
   }

--- a/src/llmButtonClickHandling.ts
+++ b/src/llmButtonClickHandling.ts
@@ -148,7 +148,7 @@ async function handleSubjectSuccessResponse(
   options: Options,
 ) {
   await browser.compose.setComposeDetails(tabId, {
-    subject: maybeStripThinkTag(subjectResponse.choices[0].message.content, options).trim(),
+    subject: maybeStripThinkTag(subjectResponse.choices[0].message.content ?? "", options).trim(),
   });
 }
 
@@ -182,7 +182,7 @@ async function getCleanedUpGeneratedEmail(
   signature: string | undefined,
   options: Options,
 ) {
-  const content = maybeStripThinkTag(response.choices[0].message.content, options);
+  const content = maybeStripThinkTag(response.choices[0].message.content ?? "", options);
   const responseWithoutSignature = signature ? content.replace(signature, "") : content;
   return responseWithoutSignature.replace(/^\s*/, "");
 }
@@ -205,7 +205,10 @@ export async function summarize(tabId: number, originalConversation?: string): P
   const requestStatus = allRequestsStatus.getRequestStatus(tabId);
   const response = await sendContentToLlm(messages, requestStatus.abortController.signal);
   if (isLlmTextCompletionResponse(response)) {
-    const content = maybeStripThinkTag((response as LlmTextCompletionResponse).choices[0].message.content, options);
+    const content = maybeStripThinkTag(
+      (response as LlmTextCompletionResponse).choices[0].message.content ?? "",
+      options,
+    );
     await browser.compose.setComposeDetails(tabId, {
       plainTextBody: `${content}\n\n\n\n${originalConversation}`,
     });

--- a/src/llmConnection.ts
+++ b/src/llmConnection.ts
@@ -4,15 +4,47 @@ import { getPluginOptions, type LlmParameters } from "./optionsParams";
 export enum LlmRoles {
   SYSTEM = "system",
   USER = "user",
+  ASSISTANT = "assistant",
+  TOOL = "tool",
+}
+
+/** An OpenAI-style tool call requested by the assistant. */
+export interface LlmToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string; // JSON-encoded arguments
+  };
 }
 
 export interface LlmApiRequestMessage {
-  content: string;
+  content: string | null;
   role: LlmRoles;
+  // Present on assistant messages that request tool calls
+  tool_calls?: LlmToolCall[];
+  // Present on tool-result messages
+  tool_call_id?: string;
+  name?: string;
 }
+
+/** OpenAI-style function tool definition advertised to the model. */
+export interface LlmToolDefinition {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>; // JSON schema
+  };
+}
+
+/** Executes a tool call and returns a JSON-serialisable result. */
+export type LlmToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
 
 export interface LlmApiRequestBody extends LlmParameters {
   messages: LlmApiRequestMessage[];
+  tools?: LlmToolDefinition[];
+  tool_choice?: "auto" | "none";
 }
 
 export interface InputToken {
@@ -30,8 +62,9 @@ export interface TokensAndLogprobs {
 
 export interface LlmChoice {
   message: {
-    content: string;
+    content: string | null;
     role: LlmRoles;
+    tool_calls?: LlmToolCall[];
   };
   index: number;
   prefill: [string];
@@ -58,7 +91,7 @@ export interface LlmTextCompletionResponse {
   logprobs?: TokensAndLogprobs;
 }
 
-type FinishReason = "length" | "eos_token" | "stop_sequence" | "error";
+type FinishReason = "length" | "eos_token" | "stop_sequence" | "error" | "tool_calls" | "stop";
 
 export interface TgiErrorResponse {
   error: {
@@ -156,4 +189,154 @@ async function callLlmApi(
 
 export function isLlmTextCompletionResponse(response: LlmTextCompletionResponse | TgiErrorResponse) {
   return "id" in response;
+}
+
+/** Log per-call token usage and return the running total. */
+function logTokenUsage(response: LlmTextCompletionResponse, runningTotal: number, step: number): number {
+  const usage = response.usage;
+  if (!usage) {
+    console.log(`REPORT: step ${step} token usage unavailable (endpoint returned no 'usage')`);
+    return runningTotal;
+  }
+  const total = runningTotal + (usage.total_tokens ?? 0);
+  console.log(
+    `REPORT: step ${step} tokens — prompt=${usage.prompt_tokens} completion=${usage.completion_tokens} ` +
+      `total=${usage.total_tokens} (run total=${total})`,
+  );
+  return total;
+}
+
+/**
+ * Run an agentic chat-completion loop with tool calling. Posts the conversation plus tool
+ * definitions, executes any requested tool calls via `toolHandlers`, and repeats until the
+ * model returns a plain message or `maxSteps` is reached. Throws if the endpoint/model does
+ * not support tool calling.
+ */
+export async function runAgenticLlm(
+  messages: LlmApiRequestMessage[],
+  tools: LlmToolDefinition[],
+  toolHandlers: Record<string, LlmToolHandler>,
+  abortSignal: AbortSignal,
+  maxSteps: number,
+): Promise<string> {
+  const options = await getPluginOptions();
+  if (!options.model) {
+    throw Error("Missing LLM model, set it in the options panel.");
+  }
+
+  const conversation: LlmApiRequestMessage[] = [...messages];
+  let totalTokens = 0;
+
+  for (let step = 1; step <= maxSteps; step++) {
+    if (abortSignal.aborted) {
+      throw new DOMException("Report generation cancelled", "AbortError");
+    }
+
+    const requestBody: LlmApiRequestBody = {
+      messages: conversation,
+      tools,
+      tool_choice: "auto",
+      ...options.params,
+    };
+
+    console.log(
+      `REPORT: step ${step}/${maxSteps} request with ${conversation.length} conversation message(s) and ${tools.length} tool(s)`,
+    );
+
+    let response: LlmTextCompletionResponse | TgiErrorResponse;
+    try {
+      response = await callLlmApi(options.model, requestBody, abortSignal, options.api_token, options.timeout);
+    } catch (e) {
+      if ((e as Error).name === "AbortError" || (e as Error).name === "TimeoutError") {
+        throw e;
+      }
+      throw new Error(
+        `LLM tool-calling request failed. Your endpoint/model may not support tool calling, which the report ` +
+          `feature requires. Original error: ${(e as Error).message}`,
+      );
+    }
+
+    if (!isLlmTextCompletionResponse(response)) {
+      const errorResponse = response as TgiErrorResponse;
+      throw new Error(
+        `The LLM endpoint rejected the tool-calling request: ${errorResponse.error?.message ?? "unknown error"}. ` +
+          `The report feature requires an endpoint/model that supports tool calling.`,
+      );
+    }
+
+    const completion = response as LlmTextCompletionResponse;
+    totalTokens = logTokenUsage(completion, totalTokens, step);
+
+    const choice = Array.isArray(completion.choices) ? completion.choices[0] : undefined;
+    if (!choice) {
+      throw new Error("LLM response did not contain any choices.");
+    }
+
+    const toolCalls = choice.message?.tool_calls;
+    if (!toolCalls || toolCalls.length === 0) {
+      // Final answer.
+      console.log(
+        `REPORT: completed after ${step} step(s), ~${totalTokens} total tokens, finalChars=${choice.message?.content?.length ?? 0}`,
+      );
+      return choice.message?.content ?? "";
+    }
+
+    console.log(
+      `REPORT: step ${step} requested ${toolCalls.length} tool call(s): ${toolCalls.map((t) => t.function.name).join(", ")}`,
+    );
+
+    // Append the assistant's tool-call request, then each tool result.
+    conversation.push({
+      role: LlmRoles.ASSISTANT,
+      content: choice.message.content ?? null,
+      tool_calls: toolCalls,
+    });
+
+    for (const toolCall of toolCalls) {
+      const handler = toolHandlers[toolCall.function.name];
+      let resultContent: string;
+      if (!handler) {
+        console.warn(`REPORT: tool '${toolCall.function.name}' is not registered`);
+        resultContent = JSON.stringify({ error: `Unknown tool: ${toolCall.function.name}` });
+      } else {
+        try {
+          const parsedArgs = parseToolArguments(toolCall.function.arguments);
+          console.log(
+            `REPORT: running tool '${toolCall.function.name}' with arg keys: ${Object.keys(parsedArgs).join(",") || "(none)"}`,
+          );
+          const result = await handler(parsedArgs);
+          resultContent = JSON.stringify(result ?? null);
+          console.log(`REPORT: tool '${toolCall.function.name}' completed (resultChars=${resultContent.length})`);
+        } catch (e) {
+          if ((e as Error).name === "AbortError") throw e;
+          console.warn(`REPORT: tool '${toolCall.function.name}' failed:`, e);
+          resultContent = JSON.stringify({ error: (e as Error).message });
+        }
+      }
+      conversation.push({
+        role: LlmRoles.TOOL,
+        tool_call_id: toolCall.id,
+        name: toolCall.function.name,
+        content: resultContent,
+      });
+    }
+  }
+
+  console.warn(`REPORT: reached max steps (${maxSteps}) without a final answer`);
+
+  throw new Error(
+    `Report generation stopped after the maximum of ${maxSteps} steps without a final answer. ` +
+      `Increase 'reportMaxSteps' in the options or simplify the request.`,
+  );
+}
+
+/** Parse tool-call arguments JSON; tolerate an empty/whitespace string as no-args. */
+function parseToolArguments(raw: string): Record<string, unknown> {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return {};
+  const parsed = JSON.parse(trimmed);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Tool arguments were not a JSON object.");
+  }
+  return parsed as Record<string, unknown>;
 }

--- a/src/llmConnection.ts
+++ b/src/llmConnection.ts
@@ -1,3 +1,4 @@
+import { hasEndpointPermission } from "./hostPermissions";
 import { startKeepAlive, stopKeepAlive } from "./keepAlive";
 import { getPluginOptions, type LlmParameters } from "./optionsParams";
 
@@ -154,6 +155,15 @@ async function callLlmApi(
         ),
       );
     }, timeout);
+  }
+
+  // MV3 host permissions are opt-in; without the grant the fetch is CORS-blocked. Fail with an
+  // actionable message instead of an opaque "Access-Control-Allow-Origin missing" console error.
+  if (!(await hasEndpointPermission(url))) {
+    throw Error(
+      `LLM-CONNECTION: Missing permission to access ${url}. Open the extension options and re-save ` +
+        `the endpoint URL to grant access to this host, then try again.`,
+    );
   }
 
   try {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,5 @@
 import { getAllFolderPaths } from "./emailOrganising";
+import { hasEndpointPermission, requestEndpointPermission } from "./hostPermissions";
 import { notifyOnError } from "./notifications";
 import { type FolderRule, getPluginOptions } from "./optionsParams";
 import { getInputElement } from "./utils";
@@ -9,6 +10,7 @@ type GetFolderPathsMessage = {
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.querySelector("#url")?.addEventListener("change", updateUrl);
+document.querySelector("#grant-access-btn")?.addEventListener("click", grantEndpointAccess);
 document.querySelector("#api_token")?.addEventListener("change", updateApiToken);
 document.querySelector("#timeout")?.addEventListener("change", updateTimeout);
 document.querySelector("#llm_context")?.addEventListener("change", updateLlmContext);
@@ -32,6 +34,43 @@ async function updateUrl(event: Event) {
     options.model = modelUrlInput.value;
     await browser.storage.sync.set({ options });
   });
+  // Reflect whether this (possibly new) endpoint origin is already permitted.
+  await updateUrlPermissionStatus();
+}
+
+/**
+ * Request the host permission for the current endpoint URL. MV3 host permissions are opt-in and
+ * permissions.request requires a real user-activation event — a button click qualifies (the
+ * input's "change" event does not), so this is wired to the "Grant access" button.
+ */
+async function grantEndpointAccess() {
+  const modelUrl = getInputElement("#url").value;
+  if (!modelUrl) {
+    await notifyOnError(async () => {
+      throw new Error("Enter the LLM endpoint URL first.");
+    });
+    return;
+  }
+  const granted = await requestEndpointPermission(modelUrl);
+  await updateUrlPermissionStatus();
+  if (!granted) {
+    await notifyOnError(async () => {
+      throw new Error("Permission to access this endpoint was not granted. The extension cannot reach the LLM.");
+    });
+  }
+}
+
+/** Show whether the extension currently has host permission for the configured endpoint. */
+async function updateUrlPermissionStatus() {
+  const statusEl = document.querySelector("#url-permission-status");
+  if (!statusEl) return;
+  const modelUrl = getInputElement("#url").value;
+  if (!modelUrl) {
+    statusEl.textContent = "";
+    return;
+  }
+  const granted = await hasEndpointPermission(modelUrl);
+  statusEl.textContent = granted ? "✅ Access granted" : '⚠️ Access not granted — click "Grant access".';
 }
 
 async function updateApiToken(event: Event) {
@@ -118,6 +157,7 @@ export async function restoreOptions(): Promise<void> {
   const options = await getPluginOptions();
 
   getInputElement("#url").value = options.model;
+  await updateUrlPermissionStatus();
   getInputElement("#api_token").value = options.api_token || "";
   getInputElement("#timeout").value = options.timeout ? `${options.timeout / 1000}` : "";
   getInputElement("#context_window").value = `${options.context_window}`;

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,6 +16,9 @@ document.querySelector("#use_last_mails")?.addEventListener("change", updateUseL
 document.querySelector("#strip_think_tag")?.addEventListener("change", updateStripThinkTag);
 document.querySelector("#context_window")?.addEventListener("change", updateContextWindow);
 document.querySelector("#other_options")?.addEventListener("change", updateOtherOptions);
+document.querySelector("#report_default_days")?.addEventListener("change", updateReportDefaultDays);
+document.querySelector("#report_max_search_results")?.addEventListener("change", updateReportMaxSearchResults);
+document.querySelector("#report_max_steps")?.addEventListener("change", updateReportMaxSteps);
 document.querySelector("#add-folder-rule-btn")?.addEventListener("click", addFolderRuleRow);
 document.querySelector("#refresh-folder-paths-btn")?.addEventListener("click", refreshFolderPaths);
 
@@ -84,6 +87,33 @@ async function updateOtherOptions(event: Event) {
   });
 }
 
+/** Persist a positive-integer numeric option, ignoring empty/invalid input. */
+async function updatePositiveIntOption(
+  event: Event,
+  key: "reportDefaultDays" | "reportMaxSearchResults" | "reportMaxSteps",
+) {
+  const input = event.target as HTMLInputElement;
+  const value = input.valueAsNumber;
+  if (!Number.isFinite(value) || value < 1) {
+    return;
+  }
+  const options = await getPluginOptions();
+  options[key] = Math.floor(value);
+  await browser.storage.sync.set({ options });
+}
+
+async function updateReportDefaultDays(event: Event) {
+  await updatePositiveIntOption(event, "reportDefaultDays");
+}
+
+async function updateReportMaxSearchResults(event: Event) {
+  await updatePositiveIntOption(event, "reportMaxSearchResults");
+}
+
+async function updateReportMaxSteps(event: Event) {
+  await updatePositiveIntOption(event, "reportMaxSteps");
+}
+
 export async function restoreOptions(): Promise<void> {
   const options = await getPluginOptions();
 
@@ -95,6 +125,9 @@ export async function restoreOptions(): Promise<void> {
   getInputElement("#strip_think_tag").checked = options.strip_think_tag ?? true;
   getInputElement("#other_options").value = JSON.stringify(options.params, null, 2);
   getInputElement("#llm_context").value = options.llmContext;
+  getInputElement("#report_default_days").value = `${options.reportDefaultDays}`;
+  getInputElement("#report_max_search_results").value = `${options.reportMaxSearchResults}`;
+  getInputElement("#report_max_steps").value = `${options.reportMaxSteps}`;
 
   const rules = options.folderSortingRules ?? [];
   const list = document.querySelector("#folder-rules-list");

--- a/src/optionsParams.ts
+++ b/src/optionsParams.ts
@@ -31,6 +31,9 @@ export interface Options {
   llmContext: string;
   timeout?: number; // Timeout in milliseconds, undefined means no timeout
   folderSortingRules: FolderRule[];
+  reportMaxSteps: number; // upper bound on agentic tool-calling iterations
+  reportMaxSearchResults: number; // cap on messages returned by a single search_messages call
+  reportDefaultDays: number; // prefilled "days in the past" value in the report window
 }
 
 export const DEFAULT_PARAMS: LlmParameters = {};
@@ -50,6 +53,9 @@ export const DEFAULT_OPTIONS: Options = {
     "[Writer's name, without the mail signature]",
   include_recent_mails: true,
   folderSortingRules: [],
+  reportMaxSteps: 8,
+  reportMaxSearchResults: 50,
+  reportDefaultDays: 30,
 };
 
 export async function getPluginOptions(): Promise<Options> {

--- a/src/reportGeneration.ts
+++ b/src/reportGeneration.ts
@@ -1,0 +1,121 @@
+import { LlmRoles, runAgenticLlm } from "./llmConnection";
+import { getPluginOptions } from "./optionsParams";
+import {
+  assertSearchCapabilities,
+  createReportToolHandlers,
+  type ReportScope,
+  reportToolDefinitions,
+} from "./reportTools";
+import { stripThinkTags } from "./utils";
+
+export interface ReportRequest {
+  prompt: string;
+  days: number;
+  folderOnly: boolean;
+  folder: { accountId: string; path: string } | null;
+  priorReport?: string;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const REPORT_SYSTEM_PROMPT = `You are an email-analysis assistant that produces reports from a user's mailbox.
+
+Work agentically:
+- Use the provided tools to gather ONLY the information you need.
+- Be token-frugal: prefer search_messages (compact metadata) and only call get_message for the
+  few messages whose bodies you truly need.
+- search_messages returns no bodies — you must call get_message to read content.
+
+When you have enough information, stop calling tools and write the final report as your message
+content. The report must be self-contained, well-structured plain text that the user can copy
+elsewhere. Do not include tool-call chatter or your reasoning in the final report.`;
+
+/** Build the scope-describing user preamble for the run. */
+function buildScopePreamble(request: ReportRequest): string {
+  const scopeText = request.folderOnly && request.folder ? `only the folder "${request.folder.path}"` : "all folders";
+  const runDate = new Date();
+  const fromDate = new Date(runDate.getTime() - request.days * DAY_MS);
+  return [
+    `Search scope: ${scopeText}.`,
+    `Time window: messages from the last ${request.days} day(s) by default.`,
+    `Default date range (computed now): ${toLocalDateYmd(fromDate)} to ${toLocalDateYmd(runDate)}.`,
+    `Report run date: ${toLocalDateYmd(runDate)}.`,
+    "If your report includes a date range or generated-on line, use these exact dates.",
+  ].join("\n");
+}
+
+function toLocalDateYmd(date: Date): string {
+  const yyyy = `${date.getFullYear()}`;
+  const mm = `${date.getMonth() + 1}`.padStart(2, "0");
+  const dd = `${date.getDate()}`.padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Run an agentic report generation for the given request. Validates search capabilities first,
+ * then loops the LLM with email-search tools, and returns the final plain-text report.
+ */
+export async function generateReport(request: ReportRequest, abortSignal: AbortSignal): Promise<string> {
+  const startedAt = Date.now();
+  const options = await getPluginOptions();
+
+  const scope: ReportScope = {
+    folderOnly: request.folderOnly,
+    folder: request.folder,
+    defaultDays: request.days,
+    maxSearchResults: options.reportMaxSearchResults,
+  };
+
+  console.log(
+    "REPORT: starting generation " +
+      `(days=${request.days}, folderOnly=${request.folderOnly}, folder=${request.folder?.path ?? "(all)"}, ` +
+      `promptChars=${request.prompt.length}, hasPriorReport=${Boolean(request.priorReport?.trim())})`,
+  );
+
+  // Hard requirement: fail loudly if the mailbox cannot be searched the way we need.
+  await assertSearchCapabilities(scope);
+  console.log("REPORT: search capability probe succeeded");
+
+  const messages = [
+    { role: LlmRoles.SYSTEM, content: REPORT_SYSTEM_PROMPT },
+    { role: LlmRoles.USER, content: buildScopePreamble(request) },
+  ];
+
+  if (request.priorReport?.trim()) {
+    messages.push({
+      role: LlmRoles.USER,
+      content:
+        "Here is the previous report. Refine it according to the new instructions below rather than " +
+        `starting from scratch:\n\n${request.priorReport.trim()}`,
+    });
+  }
+
+  messages.push({ role: LlmRoles.USER, content: `Report request:\n${request.prompt}` });
+
+  const handlers = createReportToolHandlers(scope);
+  console.log(
+    `REPORT: entering agentic loop (maxSteps=${options.reportMaxSteps}, maxSearchResults=${scope.maxSearchResults})`,
+  );
+
+  try {
+    const rawReport = await runAgenticLlm(
+      messages,
+      reportToolDefinitions,
+      handlers,
+      abortSignal,
+      options.reportMaxSteps,
+    );
+    const finalReport = options.strip_think_tag ? stripThinkTags(rawReport) : rawReport;
+
+    console.log(
+      "REPORT: generation completed " +
+        `(elapsedMs=${Date.now() - startedAt}, rawChars=${rawReport.length}, finalChars=${finalReport.length}, ` +
+        `strippedThinkTags=${options.strip_think_tag})`,
+    );
+
+    return finalReport;
+  } catch (e) {
+    console.error(`REPORT: generation failed after ${Date.now() - startedAt}ms`, e);
+    throw e;
+  }
+}

--- a/src/reportTools.ts
+++ b/src/reportTools.ts
@@ -1,0 +1,221 @@
+import { extractTextFromPart, resolveFolderPath } from "./emailOrganising";
+import type { LlmToolDefinition, LlmToolHandler } from "./llmConnection";
+
+const MAX_EMAIL_BODY_CHARS = 1200;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Folder/time scope for a single report run, derived from the report window inputs. */
+export interface ReportScope {
+  folderOnly: boolean;
+  folder: { accountId: string; path: string } | null;
+  defaultDays: number;
+  maxSearchResults: number;
+}
+
+type QueryInfo = browser.messages._QueryQueryInfo & { folderId?: string };
+
+/** Compact metadata shape returned by `search_messages` (no bodies, to stay token-frugal). */
+interface SearchHit {
+  id: number;
+  date: string;
+  author: string;
+  recipients: string[];
+  subject: string;
+}
+
+/**
+ * Verify that `browser.messages.query` accepts the parameters the report tools rely on
+ * (`fromDate`, `author`, `fullText`). Throws a clear error if querying is unavailable/broken.
+ */
+export async function assertSearchCapabilities(scope: ReportScope): Promise<void> {
+  try {
+    const probe: QueryInfo = {
+      fromDate: new Date(Date.now() - DAY_MS),
+      author: "capability-probe@example.invalid",
+      fullText: "capability-probe",
+    };
+    await browser.messages.query(probe);
+    console.log("REPORT: search capability probe query succeeded");
+  } catch (e) {
+    throw new Error(
+      `Email search is not available on this Thunderbird build (browser.messages.query failed for ` +
+        `fromDate/author/fullText): ${(e as Error).message}. The report feature cannot run.`,
+    );
+  }
+  // Touch scope so callers always pass it (folder is validated lazily during search).
+  void scope.folderOnly;
+}
+
+/** JSON-schema tool definitions advertised to the model. */
+export const reportToolDefinitions: LlmToolDefinition[] = [
+  {
+    type: "function",
+    function: {
+      name: "search_messages",
+      description:
+        "Search emails and return compact metadata only (no bodies). Use this first to find relevant " +
+        "messages, then call get_message for the few whose bodies you actually need.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Full-text search terms (optional)." },
+          author: { type: "string", description: "Filter by sender address/name (optional)." },
+          subject: { type: "string", description: "Filter by subject (case-insensitive substring; optional)." },
+          fromDays: {
+            type: "number",
+            description: "Only include messages from the last N days (optional; defaults to the run's day window).",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_message",
+      description: "Fetch the plain-text body (truncated) of a single message by its numeric id.",
+      parameters: {
+        type: "object",
+        properties: {
+          id: { type: "number", description: "The message id from search_messages." },
+        },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+/** Build tool handlers bound to a specific report scope. */
+export function createReportToolHandlers(scope: ReportScope): Record<string, LlmToolHandler> {
+  return {
+    search_messages: (args) => handleSearchMessages(args, scope),
+    get_message: (args) => handleGetMessage(args),
+  };
+}
+
+async function handleSearchMessages(args: Record<string, unknown>, scope: ReportScope): Promise<SearchHit[]> {
+  const startedAt = Date.now();
+  const queryInfo: QueryInfo = {};
+
+  const query = typeof args.query === "string" ? args.query.trim() : "";
+  if (query) queryInfo.fullText = query;
+
+  const author = typeof args.author === "string" ? args.author.trim() : "";
+  if (author) queryInfo.author = author;
+
+  // `browser.messages.query`'s `subject` is an exact full-string match, so passing a partial term
+  // (e.g. "Schulung") finds nothing. Filter subjects as a case-insensitive substring client-side instead.
+  const subject = typeof args.subject === "string" ? args.subject.trim() : "";
+  const subjectFilter = subject ? subject.toLowerCase() : "";
+
+  const fromDays = typeof args.fromDays === "number" && args.fromDays > 0 ? args.fromDays : scope.defaultDays;
+  if (fromDays > 0) {
+    queryInfo.fromDate = new Date(Date.now() - fromDays * DAY_MS);
+  }
+
+  if (scope.folderOnly && scope.folder) {
+    console.log(`REPORT: search_messages resolving folder scope '${scope.folder.path}'`);
+    const folder = await resolveFolderPath(scope.folder.path);
+    if (!folder) {
+      throw new Error(`Could not resolve the active folder "${scope.folder.path}" for a folder-only search.`);
+    }
+    const folderWithId = folder as browser.folders.MailFolder & { id?: string };
+    if (folderWithId.id) {
+      queryInfo.folderId = folderWithId.id;
+    } else {
+      queryInfo.folder = folder;
+    }
+  }
+
+  const hits: SearchHit[] = [];
+  let pageCount = 0;
+  let page = await browser.messages.query(queryInfo);
+  pageCount++;
+  collectHits(page.messages, hits, scope.maxSearchResults, subjectFilter);
+  while (page.id && hits.length < scope.maxSearchResults) {
+    page = await browser.messages.continueList(page.id);
+    pageCount++;
+    collectHits(page.messages, hits, scope.maxSearchResults, subjectFilter);
+  }
+
+  const fromDateText = queryInfo.fromDate instanceof Date ? queryInfo.fromDate.toISOString().slice(0, 10) : "(none)";
+  console.log(
+    "REPORT: search_messages completed " +
+      `(query='${query || ""}', author='${author || ""}', subject='${subject || ""}', fromDate=${fromDateText}, ` +
+      `folderOnly=${scope.folderOnly}, pages=${pageCount}, hits=${hits.length}/${scope.maxSearchResults}, ` +
+      `elapsedMs=${Date.now() - startedAt})`,
+  );
+  return hits;
+}
+
+function collectHits(
+  messages: browser.messages.MessageHeader[],
+  out: SearchHit[],
+  cap: number,
+  subjectFilter: string,
+): void {
+  for (const msg of messages) {
+    if (out.length >= cap) {
+      break;
+    }
+    if (msg.id === undefined) {
+      continue;
+    }
+    if (subjectFilter && !(msg.subject ?? "").toLowerCase().includes(subjectFilter)) {
+      continue;
+    }
+    out.push({
+      id: msg.id,
+      date: msg.date ? new Date(msg.date).toISOString() : "",
+      author: msg.author ?? "",
+      recipients: msg.recipients ?? [],
+      subject: msg.subject ?? "(no subject)",
+    });
+  }
+}
+
+async function handleGetMessage(args: Record<string, unknown>): Promise<{
+  id: number;
+  date: string;
+  author: string;
+  subject: string;
+  body: string;
+}> {
+  const startedAt = Date.now();
+  const id = typeof args.id === "number" ? args.id : Number(args.id);
+  if (!Number.isFinite(id)) {
+    throw new Error("get_message requires a numeric 'id'.");
+  }
+
+  console.log(`REPORT: get_message loading id=${id}`);
+  let header: browser.messages.MessageHeader;
+  let full: browser.messages.MessagePart;
+  try {
+    header = await browser.messages.get(id);
+    full = await browser.messages.getFull(id);
+  } catch (e) {
+    // The model sometimes invents or reuses a stale id. Return a clear, recoverable hint instead of
+    // a bare "Message not found" so it falls back to ids actually returned by search_messages.
+    console.warn(`REPORT: get_message could not load id=${id}:`, e);
+    throw new Error(
+      `No message exists with id ${id}. Only call get_message with an 'id' returned by a recent ` +
+        `search_messages result; do not guess ids. Run search_messages again if you need valid ids.`,
+    );
+  }
+  const rawBody = extractTextFromPart(full);
+  const body = rawBody.slice(0, MAX_EMAIL_BODY_CHARS);
+
+  console.log(
+    `REPORT: get_message loaded id=${id} (bodyChars=${body.length}, truncated=${rawBody.length > MAX_EMAIL_BODY_CHARS}, elapsedMs=${Date.now() - startedAt})`,
+  );
+
+  return {
+    id,
+    date: header.date ? new Date(header.date).toISOString() : "",
+    author: header.author ?? "",
+    subject: header.subject ?? "(no subject)",
+    body,
+  };
+}

--- a/src/reports-action.ts
+++ b/src/reports-action.ts
@@ -1,11 +1,21 @@
 // Action-button popup: routes to the organise-folder toggle or opens the report window.
 
 document.querySelector("#organise-btn")?.addEventListener("click", async () => {
-  await browser.runtime.sendMessage({ type: "organise-folder-toggle" });
-  window.close();
+  try {
+    await browser.runtime.sendMessage({ type: "organise-folder-toggle" });
+  } catch (e) {
+    console.error("MENU: failed to send organise-folder-toggle", e);
+  } finally {
+    window.close();
+  }
 });
 
 document.querySelector("#report-btn")?.addEventListener("click", async () => {
-  await browser.runtime.sendMessage({ type: "open-report-window" });
-  window.close();
+  try {
+    await browser.runtime.sendMessage({ type: "open-report-window" });
+  } catch (e) {
+    console.error("MENU: failed to send open-report-window", e);
+  } finally {
+    window.close();
+  }
 });

--- a/src/reports-action.ts
+++ b/src/reports-action.ts
@@ -1,0 +1,11 @@
+// Action-button popup: routes to the organise-folder toggle or opens the report window.
+
+document.querySelector("#organise-btn")?.addEventListener("click", async () => {
+  await browser.runtime.sendMessage({ type: "organise-folder-toggle" });
+  window.close();
+});
+
+document.querySelector("#report-btn")?.addEventListener("click", async () => {
+  await browser.runtime.sendMessage({ type: "open-report-window" });
+  window.close();
+});

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -1,0 +1,143 @@
+import { getPluginOptions } from "./optionsParams";
+import type { ReportRequest } from "./reportGeneration";
+import { getInputElement } from "./utils";
+
+TODO:
+make popup look more like copilot: icnos instead of buttons, no cancel, number of days in same line as checkbox, but keep report field at the bottom
+
+
+const params = new URLSearchParams(window.location.search);
+const folderContext =
+  params.get("accountId") && params.get("path")
+    ? { accountId: params.get("accountId") as string, path: params.get("path") as string }
+    : null;
+const folderName = params.get("name") ?? folderContext?.path ?? "";
+
+let windowId: number | undefined;
+let busy = false;
+let lastReport = "";
+
+const folderOnlyInput = getInputElement("#folder-only");
+const daysInput = getInputElement("#days");
+const promptInput = document.querySelector<HTMLTextAreaElement>("#prompt");
+const outputArea = document.querySelector<HTMLTextAreaElement>("#report-output");
+const statusEl = document.querySelector<HTMLParagraphElement>("#status");
+const busyImg = document.querySelector<HTMLImageElement>("#busy");
+const createBtn = getInputElement("#create-btn");
+const cancelBtn = getInputElement("#cancel-btn");
+const copyBtn = getInputElement("#copy-btn");
+const scopeNote = document.querySelector<HTMLParagraphElement>("#scope-note");
+
+void init();
+
+async function init(): Promise<void> {
+  const current = await browser.windows.getCurrent();
+  windowId = current.id;
+
+  const options = await getPluginOptions();
+  daysInput.value = `${options.reportDefaultDays}`;
+
+  if (!folderContext) {
+    // No folder context (e.g. opened without an active mail folder): search everywhere.
+    folderOnlyInput.checked = false;
+    folderOnlyInput.disabled = true;
+  }
+  updateScopeNote();
+
+  folderOnlyInput.addEventListener("change", updateScopeNote);
+  createBtn.addEventListener("click", onCreate);
+  cancelBtn.addEventListener("click", onCancel);
+  copyBtn.addEventListener("click", onCopy);
+  setStatus("Ready.");
+}
+
+function updateScopeNote(): void {
+  if (!scopeNote) return;
+  if (folderOnlyInput.checked && folderContext) {
+    scopeNote.textContent = `Scope: "${folderName}" only.`;
+  } else {
+    scopeNote.textContent = "Scope: all folders.";
+  }
+}
+
+function setBusy(value: boolean): void {
+  busy = value;
+  createBtn.disabled = value;
+  busyImg?.classList.toggle("show", value);
+}
+
+function setStatus(text: string): void {
+  if (!statusEl) return;
+  // Keep the busy image; replace only the trailing text node.
+  const tail = statusEl.lastChild;
+  if (tail && tail.nodeType === Node.TEXT_NODE) {
+    tail.textContent = text;
+  } else {
+    statusEl.appendChild(document.createTextNode(text));
+  }
+}
+
+async function onCreate(): Promise<void> {
+  if (busy) return;
+  const prompt = promptInput?.value.trim() ?? "";
+  if (!prompt) {
+    setStatus("Please enter a report request first.");
+    return;
+  }
+
+  const days = daysInput.valueAsNumber > 0 ? daysInput.valueAsNumber : 30;
+  const folderOnly = folderOnlyInput.checked && !!folderContext;
+
+  const request: ReportRequest = {
+    prompt,
+    days,
+    folderOnly,
+    folder: folderContext,
+    priorReport: lastReport || undefined,
+  };
+
+  setBusy(true);
+  setStatus("Generating report… this may take a while.");
+  try {
+    const response = (await browser.runtime.sendMessage({ type: "generate-report", windowId, request })) as {
+      report?: string;
+      error?: string;
+    };
+    if (response?.error) {
+      setStatus(`Error: ${response.error}`);
+      return;
+    }
+    lastReport = response?.report ?? "";
+    if (outputArea) outputArea.value = lastReport;
+    setStatus("Report ready. Refine the prompt and click Create to iterate.");
+  } catch (e) {
+    setStatus(`Error: ${(e as Error).message}`);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function onCancel(): Promise<void> {
+  if (busy) {
+    await browser.runtime.sendMessage({ type: "cancel-report", windowId });
+    setStatus("Cancelling…");
+    return;
+  }
+  window.close();
+}
+
+async function onCopy(): Promise<void> {
+  if (!outputArea?.value) {
+    setStatus("Nothing to copy yet.");
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(outputArea.value);
+    setStatus("Report copied to clipboard.");
+  } catch {
+    // Fallback for environments without async clipboard access.
+    outputArea.select();
+    document.execCommand("copy");
+    setStatus("Report copied to clipboard.");
+  }
+}

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -25,7 +25,7 @@ const saveTxtBtn = getButtonElement("#save-txt-btn");
 const saveMdBtn = getButtonElement("#save-md-btn");
 const scopeNote = document.querySelector<HTMLParagraphElement>("#scope-note");
 
-void init();
+init().catch((e) => console.error("REPORT-WINDOW: initialization failed", e));
 
 async function init(): Promise<void> {
   const current = await browser.windows.getCurrent();

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -1,10 +1,6 @@
 import { getPluginOptions } from "./optionsParams";
 import type { ReportRequest } from "./reportGeneration";
-import { getInputElement } from "./utils";
-
-TODO:
-make popup look more like copilot: icnos instead of buttons, no cancel, number of days in same line as checkbox, but keep report field at the bottom
-
+import { getButtonElement, getInputElement } from "./utils";
 
 const params = new URLSearchParams(window.location.search);
 const folderContext =
@@ -23,9 +19,10 @@ const promptInput = document.querySelector<HTMLTextAreaElement>("#prompt");
 const outputArea = document.querySelector<HTMLTextAreaElement>("#report-output");
 const statusEl = document.querySelector<HTMLParagraphElement>("#status");
 const busyImg = document.querySelector<HTMLImageElement>("#busy");
-const createBtn = getInputElement("#create-btn");
-const cancelBtn = getInputElement("#cancel-btn");
-const copyBtn = getInputElement("#copy-btn");
+const createBtn = getButtonElement("#create-btn");
+const copyBtn = getButtonElement("#copy-btn");
+const saveTxtBtn = getButtonElement("#save-txt-btn");
+const saveMdBtn = getButtonElement("#save-md-btn");
 const scopeNote = document.querySelector<HTMLParagraphElement>("#scope-note");
 
 void init();
@@ -46,8 +43,9 @@ async function init(): Promise<void> {
 
   folderOnlyInput.addEventListener("change", updateScopeNote);
   createBtn.addEventListener("click", onCreate);
-  cancelBtn.addEventListener("click", onCancel);
   copyBtn.addEventListener("click", onCopy);
+  saveTxtBtn.addEventListener("click", () => saveReport("txt"));
+  saveMdBtn.addEventListener("click", () => saveReport("md"));
   setStatus("Ready.");
 }
 
@@ -62,7 +60,11 @@ function updateScopeNote(): void {
 
 function setBusy(value: boolean): void {
   busy = value;
-  createBtn.disabled = value;
+  // While generating, the send button turns into a stop control (Copilot-style),
+  // so it must stay enabled to allow cancelling.
+  createBtn.classList.toggle("busy", value);
+  createBtn.title = value ? "Stop generating" : "Create report";
+  createBtn.setAttribute("aria-label", value ? "Stop generating" : "Create report");
   busyImg?.classList.toggle("show", value);
 }
 
@@ -78,7 +80,13 @@ function setStatus(text: string): void {
 }
 
 async function onCreate(): Promise<void> {
-  if (busy) return;
+  if (busy) {
+    // The button acts as a stop control while a report is being generated.
+    await browser.runtime.sendMessage({ type: "cancel-report", windowId });
+    setStatus("Cancelling…");
+    return;
+  }
+
   const prompt = promptInput?.value.trim() ?? "";
   if (!prompt) {
     setStatus("Please enter a report request first.");
@@ -117,13 +125,24 @@ async function onCreate(): Promise<void> {
   }
 }
 
-async function onCancel(): Promise<void> {
-  if (busy) {
-    await browser.runtime.sendMessage({ type: "cancel-report", windowId });
-    setStatus("Cancelling…");
+/** Download the current report as a text or markdown file via a temporary object URL. */
+function saveReport(extension: "txt" | "md"): void {
+  const content = outputArea?.value ?? "";
+  if (!content) {
+    setStatus("Nothing to save yet.");
     return;
   }
-  window.close();
+  const mimeType = extension === "md" ? "text/markdown" : "text/plain";
+  const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `llm-composer-report.${extension}`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  setStatus(`Report saved as .${extension}.`);
 }
 
 async function onCopy(): Promise<void> {

--- a/src/thunderbird-alarms.d.ts
+++ b/src/thunderbird-alarms.d.ts
@@ -19,6 +19,7 @@ declare namespace browser {
   export import runtime = messenger.runtime;
   export import storage = messenger.storage;
   export import tabs = messenger.tabs;
+  export import windows = messenger.windows;
 
   export namespace alarms {
     interface Alarm {

--- a/src/thunderbird-alarms.d.ts
+++ b/src/thunderbird-alarms.d.ts
@@ -16,6 +16,7 @@ declare namespace browser {
   export import menus = messenger.menus;
   export import messages = messenger.messages;
   export import notifications = messenger.notifications;
+  export import permissions = messenger.permissions;
   export import runtime = messenger.runtime;
   export import storage = messenger.storage;
   export import tabs = messenger.tabs;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,14 @@ export function getInputElement(selector: string): HTMLInputElement {
   return inputElement;
 }
 
+export function getButtonElement(selector: string): HTMLButtonElement {
+  const buttonElement = document.querySelector(selector) as HTMLButtonElement | null;
+  if (!buttonElement) {
+    throw Error(`Selector "${selector}" could not be found. Contact devs`);
+  }
+  return buttonElement;
+}
+
 /** Remove `<think>...</think>` reasoning blocks (including an unterminated trailing one) from LLM output. */
 export function stripThinkTags(text: string): string {
   return text

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,14 @@ export function getInputElement(selector: string): HTMLInputElement {
   return inputElement;
 }
 
+/** Remove `<think>...</think>` reasoning blocks (including an unterminated trailing one) from LLM output. */
+export function stripThinkTags(text: string): string {
+  return text
+    .replace(/<think\b[^>]*>[\s\S]*?<\/think>/gi, "")
+    .replace(/<think\b[^>]*>[\s\S]*$/gi, "")
+    .trim();
+}
+
 export function stripHtml(html: string): string {
   return html
     .replace(/<[^>]*>/g, " ") // replace tags with a space to avoid word-merging

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,8 @@ module.exports = (_env, argv) => {
     entry: {
       options: "./src/options.ts",
       background: "./src/background.ts",
+      reports: "./src/reports.ts",
+      "reports-action": "./src/reports-action.ts",
     },
     output: {
       path: path.resolve(__dirname, buildFolder),


### PR DESCRIPTION
## Summary
Adds a **Create Report** feature and fixes MV3 host-permission handling that blocked LLM requests.

## What's new
- **Report popup**: describe a report in natural language; an agentic tool-calling loop searches your mail and generates it. Supports folder scoping, "last N days", iterative refinement, and Copy / Save as `.txt` / `.md`.
- **MV3 host permissions**: endpoint access is opt-in on MV3, so `fetch` was CORS-blocked. Added a **Grant access** button + status on the options page and an actionable error when the permission is missing.
- New options: `reportDefaultDays`, `reportMaxSearchResults`, `reportMaxSteps`.

## Fixes
- Report popup URL resolved relative to the options page so it works in both dev (repo root) and packaged (`build/`) layouts.

## Tests
109 passing, `biome ci` clean, production build succeeds. Adds `hostPermissions.test.ts`, `reports.test.ts`, and extends `llmConnection`/`options` tests.

## Reviewer notes
- Open **Options**, set the endpoint URL, and click **Grant access** — required for compose, summarize, and reports on MV3.
- The report feature requires a tool-calling-capable endpoint/model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a report creation workflow for generating mailbox reports with configurable date range, folder scope, search limits, and step limits.
  * Added options to save reports as TXT or Markdown files and copy them to the clipboard.
  * Added a toolbar action menu for organizing folders and creating reports.
  * Added endpoint access controls with status feedback and a “Grant access” option.
* **Bug Fixes**
  * Improved handling of incomplete LLM responses to prevent content-processing errors.
* **Documentation**
  * Expanded feature, configuration, workflow, and project usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->